### PR TITLE
Python 3.7 Support

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -11,12 +11,15 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python_version: [3.7, 3.8, 3.9]
+        python_version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: {{ matrix.python_version }}
+          python-version: ${{ matrix.python_version }}
       - name: Cache pip
         uses: actions/cache@v2
         with:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -9,11 +9,14 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      matrix:
+        python_version: [3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: {{ matrix.python_version }}
       - name: Cache pip
         uses: actions/cache@v2
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ include = [
     "examples/**",
     "tests/**"
 ]
+exclude = [
+    "build/**",
+]
 
 reportUnknownMemberType = "none"
 reportImportCycles = "none"

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ setup(
     },
     install_requires=install_requires,
     extras_require=extra_deps,
-    python_requires='>=3.8',
+    python_requires='>=3.7',
     ext_package="yahp",
 )

--- a/yahp/utils/interactive.py
+++ b/yahp/utils/interactive.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from typing import List, Literal, Optional, Union, overload
+from typing import TYPE_CHECKING, List, Optional, Union, overload
+
+if TYPE_CHECKING:
+    from typing import Literal
 
 
 class _InvalidResponseException(ValueError):

--- a/yahp/utils/iter_helpers.py
+++ b/yahp/utils/iter_helpers.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Tuple, TypeVar, Union
 T = TypeVar("T")
 
 
-def ensure_tuple(x: Union[T, Tuple[T, ...], List[T], Dict[Any, T]], /) -> Tuple[T, ...]:
+def ensure_tuple(x: Union[T, Tuple[T, ...], List[T], Dict[Any, T]]) -> Tuple[T, ...]:
     """Converts ``x`` to a :class:`tuple`
 
     Args:

--- a/yahp/utils/type_helpers.py
+++ b/yahp/utils/type_helpers.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import json
 from dataclasses import MISSING, Field
 from enum import Enum
-from typing import Any, Sequence, Tuple, Type, Union, get_args, get_origin
+from typing import Any, Sequence, Tuple, Type, Union
 
 import yahp as hp
 from yahp.utils.iter_helpers import ensure_tuple
+from yahp.utils.typing_future import get_args, get_origin
 
 
 class _JSONDict:  # sentential for representing JSON dictionary types
@@ -289,7 +290,7 @@ class HparamsType:
         return ans
 
 
-def is_field_required(f: Field[Any], /) -> bool:
+def is_field_required(f: Field[Any]) -> bool:
     """
     Returns whether a field is required
     (i.e. does not have a default value).
@@ -300,7 +301,7 @@ def is_field_required(f: Field[Any], /) -> bool:
     return get_default_value(f) == MISSING
 
 
-def get_default_value(f: Field[Any], /) -> Any:
+def get_default_value(f: Field[Any]) -> Any:
     """Returns an instance of a default value for a field.
     
     Args:
@@ -313,7 +314,7 @@ def get_default_value(f: Field[Any], /) -> Any:
     return MISSING
 
 
-def to_bool(x: Any, /):
+def to_bool(x: Any):
     """Converts a value to a boolean
     
     Args:
@@ -328,7 +329,7 @@ def to_bool(x: Any, /):
     raise TypeError(f"Could not parse {x} as bool")
 
 
-def is_none_like(x: Any, /, *, allow_list: bool) -> bool:
+def is_none_like(x: Any, *, allow_list: bool) -> bool:
     """Returns whether a value is ``None``, ``"none"``, ``[""]``, or ``["none"]``
     
     Args:

--- a/yahp/utils/typing_future.py
+++ b/yahp/utils/typing_future.py
@@ -1,0 +1,50 @@
+# pyright: reportUnusedImport=none
+
+# Future functions from typing for compatibility with python 3.7
+
+import collections.abc
+from typing import Generic, _GenericAlias  # type: ignore
+
+try:
+    from typing import get_args
+except ImportError:
+    # From https://github.com/python/cpython/blob/3.8/Lib/typing.py#L1292
+    def get_args(tp):
+        """Get type arguments with all substitutions performed.
+        For unions, basic simplifications used by Union constructor are performed.
+        Examples::
+            get_args(Dict[str, int]) == (str, int)
+            get_args(int) == ()
+            get_args(Union[int, Union[T, int], str][int]) == (int, str)
+            get_args(Union[int, Tuple[T, int]][str]) == (int, Tuple[str, int])
+            get_args(Callable[[], T][int]) == ([], int)
+        """
+        if isinstance(tp, _GenericAlias) and not tp._special:
+            res = tp.__args__
+            if get_origin(tp) is collections.abc.Callable and res[0] is not Ellipsis:
+                res = (list(res[:-1]), res[-1])
+            return res
+        return ()
+
+
+try:
+    from typing import get_origin
+except ImportError:
+    # From https://github.com/python/cpython/blob/3.8/Lib/typing.py#L1271
+    def get_origin(tp):
+        """Get the unsubscripted version of a type.
+        This supports generic types, Callable, Tuple, Union, Literal, Final and ClassVar.
+        Return None for unsupported types. Examples::
+            get_origin(Literal[42]) is Literal
+            get_origin(int) is None
+            get_origin(ClassVar[int]) is ClassVar
+            get_origin(Generic) is Generic
+            get_origin(Generic[T]) is Generic
+            get_origin(Union[T, int]) is Union
+            get_origin(List[Tuple[T, T]][int]) == list
+        """
+        if isinstance(tp, _GenericAlias):
+            return tp.__origin__
+        if tp is Generic:  # type: ignore
+            return Generic  # type: ignore
+        return None


### PR DESCRIPTION
1. Removed positional-only arguments
2. Backported `typing.get_origin` and `typing.get_args` to `typing_future.py`, since these functions were added in python 3.8.