### PR TITLE
Updated default behavior of create()

### DIFF
--- a/yahp/create/create.py
+++ b/yahp/create/create.py
@@ -405,7 +405,7 @@ def create(
     cls: Type[THparams],
     data: Optional[Dict[str, JSON]] = None,
     f: Union[str, TextIO, pathlib.PurePath, None] = None,
-    cli_args: Union[List[str], bool] = True,
+    cli_args: Union[List[str], bool, None] = None,
 ) -> THparams:
     """Create a instance of :class:`~yahp.hparams.Hparams`.
 
@@ -419,13 +419,18 @@ def create(
             the :class:`~yahp.hparams.Hparams`. Cannot be specified with ``f``.
         cli_args (Union[List[str], bool], optional): CLI argument overrides.
             Can either be a list of CLI argument,
-            True (the default) to load CLI arguments from ``sys.argv``,
+            True to load CLI arguments from ``sys.argv``,
             or False to not use any CLI arguments.
+            Default is to load CLI arguments from ``sys.arg`` only when both `data` and `f`
+            are not specified. Otherwise, CLI arguments are ignored.
 
     Returns:
         THparams: An instance of :class:`~yahp.hparams.Hparams`.
     """
     argparsers: List[argparse.ArgumentParser] = []
+    if cli_args is None:
+        cli_args == (data is None and f is None)
+    assert cli_args is not None, "invariant error"
     remaining_cli_args = _get_remaining_cli_args(cli_args)
     try:
         hparams, output_f = _get_hparams(cls=cls,

--- a/yahp/create/create.py
+++ b/yahp/create/create.py
@@ -429,8 +429,7 @@ def create(
     """
     argparsers: List[argparse.ArgumentParser] = []
     if cli_args is None:
-        cli_args == (data is None and f is None)
-    assert cli_args is not None, "invariant error"
+        cli_args = data is None and f is None
     remaining_cli_args = _get_remaining_cli_args(cli_args)
     try:
         hparams, output_f = _get_hparams(cls=cls,
@@ -536,7 +535,7 @@ def get_argparse(
     cls: Type[THparams],
     data: Optional[Dict[str, JSON]] = None,
     f: Union[str, TextIO, pathlib.PurePath, None] = None,
-    cli_args: Union[List[str], bool] = True,
+    cli_args: Union[List[str], bool, None] = None,
 ) -> argparse.ArgumentParser:
     """Get an :class:`~argparse.ArgumentParser` containing all CLI arguments.
 
@@ -550,13 +549,17 @@ def get_argparse(
             the :class:`~yahp.hparams.Hparams`. Cannot be specified with ``f``.
         cli_args (Union[List[str], bool], optional): CLI argument overrides.
             Can either be a list of CLI argument,
-            `true` (the default) to load CLI arguments from `sys.argv`,
-            or `false` to not use any CLI arguments.
+            True to load CLI arguments from ``sys.argv``,
+            or False to not use any CLI arguments.
+            Default is to load CLI arguments from ``sys.arg`` only when both `data` and `f`
+            are not specified. Otherwise, CLI arguments are ignored.
 
     Returns:
         argparse.ArgumentParser: An argparser with all CLI arguments, but without any help.
     """
     argparsers: List[argparse.ArgumentParser] = []
+    if cli_args is None:
+        cli_args = data is None and f is None
 
     remaining_cli_args = _get_remaining_cli_args(cli_args)
 

--- a/yahp/hparams.py
+++ b/yahp/hparams.py
@@ -93,7 +93,7 @@ class Hparams(ABC):
         cls: Type[THparams],
         f: Union[str, None, TextIO, pathlib.PurePath] = None,
         data: Optional[Dict[str, JSON]] = None,
-        cli_args: Union[List[str], bool] = True,
+        cli_args: Union[List[str], bool, None] = None,
     ) -> THparams:
         """Create a instance of :class:`Hparams`.
 
@@ -105,10 +105,12 @@ class Hparams(ABC):
             data (Optional[Dict[str, JSON]], optional):
                 If specified, uses this dictionary for instantiating
                 the :class:`Hparams`. Cannot be specified with ``f``.
-            cli_args (Union[List[str], bool], optional):
-                CLI argument overrides.
-                If True (the default), load CLI arguments from `sys.argv`.
-                If False, then do not use any CLI arguments.
+            cli_args (Union[List[str], bool], optional): CLI argument overrides.
+                Can either be a list of CLI argument,
+                True to load CLI arguments from ``sys.argv``,
+                or False to not use any CLI arguments.
+                Default is to load CLI arguments from ``sys.arg`` only when both `data` and `f`
+                are not specified. Otherwise, CLI arguments are ignored.
 
         Returns:
             Hparams: An instance of the class.
@@ -120,7 +122,7 @@ class Hparams(ABC):
         cls: Type[THparams],
         f: Union[str, None, TextIO, pathlib.PurePath] = None,
         data: Optional[Dict[str, JSON]] = None,
-        cli_args: Union[List[str], bool] = True,
+        cli_args: Union[List[str], bool, None] = None,
     ) -> argparse.ArgumentParser:
         return get_argparse(cls, data=data, f=f, cli_args=cli_args)
 


### PR DESCRIPTION
Instead of always loading cli args from sys.argv by default,
create() now only loads cli_args
if both `data` and `f` are not specified.

Fixes an issue in Jupyter / Colab where the python kernel is
executed with CLI args that conflict with YAHP.