### PR TITLE
Lists of hparams are now parsed from dictionaries in yamls

### DIFF
--- a/tests/fixtures/commented_map.yaml
+++ b/tests/fixtures/commented_map.yaml
@@ -34,12 +34,14 @@ nullable_required_subhparams_field:
   default_true: true                         #                 bool (Optional). Description: defaults to true.
 # List[OptionalBooleansHparam] (Required). Description: required_subhparams_field.
 required_subhparams_field_list:
-- default_false: true
-  default_true: true
+  '0':
+    default_false: true
+    default_true: true
 # Optional[List[OptionalBooleansHparam]] (Required). Description: nullable_required_subhparams_field.
 nullable_required_subhparams_field_list:
-- default_false: false                       #                 bool (Optional). Description: defaults to false.
-  default_true: true                         #                 bool (Optional). Description: defaults to true.
+  '0':
+    default_false: false                     #                 bool (Optional). Description: defaults to false.
+    default_true: true                       #                 bool (Optional). Description: defaults to true.
 #   ChoiceHparamParent (Required). Description: choice Hparam field. Options: ChoiceOneHparam, ChoiceTwoHparam, ChoiceThreeHparam.
 required_choice:
   one:                                       # ChoiceOneHparam
@@ -84,10 +86,10 @@ nullable_required_choice:
     intfield: 0
 # List[ChoiceHparamParent] (Required). Description: choice Hparam field. Options: ChoiceOneHparam, ChoiceTwoHparam, ChoiceThreeHparam.
 required_choice_list:
-- one:                                       # ChoiceOneHparam
+  one:                                       # ChoiceOneHparam
     commonfield:                             #                 bool (Required). Description: bool common field.
     intfield:                                #                  int (Required). Description: int field.
-- two:                                       # ChoiceTwoHparam
+  two:                                       # ChoiceTwoHparam
     commonfield:                             #                 bool (Required). Description: bool common field.
     primitive_hparam:                        #      PrimitiveHparam (Required). Description: Primitive Hparams.
       intfield:                              #                  int (Required). Description: int field.
@@ -99,7 +101,7 @@ required_choice_list:
       enumstringfield:
       jsonfield:                             #                 JSON (Required). Description: Required json type.
     boolfield:                               #                  int (Required). Description: int field.
-- three:                                     # ChoiceThreeHparam
+  three:                                     # ChoiceThreeHparam
     commonfield:                             #                 bool (Required). Description: bool common field.
 #   ChoiceHparamParent (Required). Description: choice Hparam field. Options: ChoiceOneHparam, ChoiceTwoHparam.
     choice:
@@ -121,7 +123,7 @@ required_choice_list:
     strfield:                                #                  str (Required). Description: str field.
 # Optional[List[ChoiceHparamParent]] (Required). Description: choice Hparam field. Options: ChoiceOneHparam, ChoiceTwoHparam, ChoiceThreeHparam.
 nullable_required_choice_list:
-- one:
+  one:
     commonfield: true
     intfield: 0
 #      Optional[float] (Optional). Description: optional float field default 1.
@@ -170,13 +172,14 @@ optional_choice_default_not_none:
 optional_choice_default_none:
 # List[OptionalBooleansHparam] (Optional). Description: optional subhparams field default not none.
 optional_subhparams_field_default_not_none_list:
-- default_false: false
-  default_true: true
+  '0':
+    default_false: false
+    default_true: true
 # Optional[List[OptionalBooleansHparam]] (Optional). Description: optional subhparams field default None. Defaults to None.
 optional_subhparams_field_default_none_list:
 # List[ChoiceHparamParent] (Optional). Description: choice Hparam field. Options: ChoiceOneHparam, ChoiceTwoHparam, ChoiceThreeHparam.
 optional_choice_default_not_none_list:
-- one:
+  one:
     commonfield: false
     intfield: 0
 # Optional[List[ChoiceHparamParent]] (Optional). Description: choice Hparam field. Defaults to None. Options: ChoiceOneHparam, ChoiceTwoHparam, ChoiceThreeHparam.

--- a/tests/test_yahp_list_from_yaml_dict.py
+++ b/tests/test_yahp_list_from_yaml_dict.py
@@ -60,16 +60,6 @@ def dict_to_list(data: Dict[str, Dict]) -> List[Dict]:
     return [{k: v} for k, v in data.items()]
 
 
-@pytest.fixture
-def parent_list_hp(data):
-    return ParentListHP.create(data={"foos": data})
-
-
-@pytest.fixture
-def parent_list_hp_no_registry(data):
-    return ParentListHPNoRegistry.create(data=data)
-
-
 def test_list_without_registry(baz):
     data = get_data(baz)
     hp = ParentListHPNoRegistry.create(data={"foos": data})

--- a/tests/test_yahp_list_from_yaml_dict.py
+++ b/tests/test_yahp_list_from_yaml_dict.py
@@ -1,11 +1,3 @@
-"""Testing needs
-
-    5. Argparse override with list  without registry - F
-    7. Argparse override with list without registry with duplicate - F
-    8. Argparse override with list with registry with duplicate - F
-    10. List object without registry with list yaml - F
-"""
-
 from dataclasses import dataclass
 from typing import List
 

--- a/tests/test_yahp_list_from_yaml_dict.py
+++ b/tests/test_yahp_list_from_yaml_dict.py
@@ -1,0 +1,256 @@
+"""Testing needs
+
+    5. Argparse override with list  without registry - F
+    7. Argparse override with list without registry with duplicate - F
+    8. Argparse override with list with registry with duplicate - F
+    10. List object without registry with list yaml - F
+"""
+
+from dataclasses import dataclass
+from typing import List
+
+import pytest
+
+import yahp as hp
+
+
+@dataclass
+class Foo(hp.Hparams):
+    baz: int = hp.required(doc="int")
+
+
+@dataclass
+class Bar(hp.Hparams):
+    baz: int = hp.required(doc="int")
+
+
+@dataclass
+class ParentListHP(hp.Hparams):
+    hparams_registry = {"foos": {"foo": Foo, "bar": Bar}}
+    foos: List[hp.Hparams] = hp.required(doc="All the foos")
+
+
+@dataclass
+class ParentListHPNoRegistry(hp.Hparams):
+    foos: List[Foo] = hp.required(doc="All the foos")
+
+
+@pytest.fixture
+def baz():
+    return 1
+
+
+@pytest.fixture
+def duplicate():
+    return False
+
+
+@pytest.fixture
+def bar():
+    return True
+
+
+@pytest.fixture(params=(False, True))
+def as_list(request):
+    return request.param
+
+
+def get_data(baz, bar=False, duplicate=False, as_list=False):
+    d = {"foo": {"baz": baz}}
+    if bar:
+        d["bar"] = {"baz": baz}
+    if duplicate:
+        d["foo+1"] = {"baz": baz + 1}
+    if as_list:
+        d = dict_to_list(d)
+    return d
+
+
+def dict_to_list(data):
+    return [{k: v} for k, v in data.items()]
+
+
+@pytest.fixture
+def parent_list_hp(data):
+    return ParentListHP.create(data={"foos": data})
+
+
+@pytest.fixture
+def parent_list_hp_no_registry(data):
+    return ParentListHPNoRegistry.create(data=data)
+
+
+def test_list_without_registry(baz):
+    data = get_data(baz)
+    hp = ParentListHPNoRegistry.create(data={"foos": data})
+
+    assert isinstance(hp.foos, list)
+    assert len(hp.foos) == 1
+    assert hp.foos[0].baz == baz
+
+
+@pytest.mark.filterwarnings("ignore:MalformedYAMLWarning")
+def test_list_without_registry_passed_list(baz):
+    data = get_data(baz, as_list=True)
+    hp = ParentListHPNoRegistry.create(data={"foos": data})
+
+    assert isinstance(hp.foos, list)
+    assert len(hp.foos) == 1
+    assert hp.foos[0].baz == baz
+
+
+def test_list_without_registry_duplicate(baz):
+    data = get_data(baz, duplicate=True)
+    hp = ParentListHPNoRegistry.create(data={"foos": data})
+
+    assert isinstance(hp.foos, list)
+    assert len(hp.foos) == 2
+    foo0 = hp.foos[0]
+    assert foo0.baz == baz
+    foo1 = hp.foos[1]
+    assert foo1.baz == baz + 1
+
+
+# Expected to fail while we do not allow CLI overrides of unregistered lists
+@pytest.mark.xfail
+def test_list_without_registry_cli_override(baz):
+    data = get_data(baz)
+    cli_args = ["--foos.foo.baz", str(baz + 2)]
+    hp = ParentListHPNoRegistry.create(cli_args=cli_args, data={"foos": data})
+
+    assert isinstance(hp.foos, list)
+    assert len(hp.foos) == 1
+    assert hp.foos[0].baz == baz + 2
+
+
+# Expected to fail while we do not allow CLI overrides of unregistered lists
+@pytest.mark.xfail
+def test_list_without_registry_duplicate_cli_override(baz):
+    data = get_data(baz, duplicate=True)
+    cli_args = ["--foos.foo+1.baz", str(baz + 2)]
+    hp = ParentListHPNoRegistry.create(cli_args=cli_args, data={"foos": data})
+
+    assert isinstance(hp.foos, list)
+    assert len(hp.foos) == 2
+
+    foo0 = hp.foos[0]
+    assert isinstance(foo0, Foo)
+    assert foo0.baz == 1
+
+    foo1 = hp.foos[1]
+    assert isinstance(foo1, Foo)
+    assert foo1.baz == baz + 2
+
+
+def test_list_with_registry(baz):
+    data = get_data(baz, bar=True)
+    hp = ParentListHP.create(data={"foos": data})
+    assert isinstance(hp.foos, list)
+    assert len(hp.foos) == 2
+    foo = hp.foos[0]
+    assert isinstance(foo, Foo)
+    assert foo.baz == baz
+
+    bar = hp.foos[1]
+    assert isinstance(bar, Bar)
+    assert bar.baz == baz
+
+
+@pytest.mark.filterwarnings("ignore:MalformedYAMLWarning")
+def test_list_with_registry_passed_list(baz):
+    data = get_data(baz, bar=True, as_list=True)
+    hp = ParentListHP.create(data={"foos": data})
+    assert isinstance(hp.foos, list)
+    assert len(hp.foos) == 2
+    foo = hp.foos[0]
+    assert isinstance(foo, Foo)
+    assert foo.baz == baz
+
+    bar = hp.foos[1]
+    assert isinstance(bar, Bar)
+    assert bar.baz == baz
+
+
+def test_list_with_registry_duplicate(baz):
+    data = get_data(baz, bar=True, duplicate=True)
+    hp = ParentListHP.create(data={"foos": data})
+    assert isinstance(hp.foos, list)
+    assert len(hp.foos) == 3
+    foo0 = hp.foos[0]
+    assert isinstance(foo0, Foo)
+    assert foo0.baz == baz
+
+    bar = hp.foos[1]
+    assert isinstance(bar, Bar)
+    assert bar.baz == baz
+
+    foo1 = hp.foos[2]
+    assert isinstance(foo1, Foo)
+    assert foo1.baz == baz + 1
+
+
+def test_list_with_registry_cli_override(baz):
+    data = get_data(baz, bar=True)
+    cli_args = ["--foos.foo.baz", str(baz + 2)]
+    hp = ParentListHP.create(cli_args=cli_args, data={"foos": data})
+    assert isinstance(hp.foos, list)
+    assert len(hp.foos) == 2
+    foo = hp.foos[0]
+    assert isinstance(foo, Foo)
+    assert foo.baz == baz + 2
+
+    bar = hp.foos[1]
+    assert isinstance(bar, Bar)
+    assert bar.baz == baz
+
+
+@pytest.mark.filterwarnings("ignore:MalformedYAMLWarning")
+def test_list_with_registry_cli_override_custom_list(baz):
+    data = get_data(baz, bar=True)
+    cli_args = ["--foos", "foo"]
+    hp = ParentListHP.create(cli_args=cli_args, data={"foos": data})
+    assert isinstance(hp.foos, list)
+    assert len(hp.foos) == 1
+    foo = hp.foos[0]
+    assert isinstance(foo, Foo)
+    assert foo.baz == baz
+
+
+#@pytest.mark.xfail
+def test_list_with_registry_duplicate_cli_override(baz):
+    data = get_data(baz, bar=True, duplicate=True)
+    cli_args = ["--foos.foo+1.baz", str(baz + 2)]
+    hp = ParentListHP.create(cli_args=cli_args, data={"foos": data})
+    assert isinstance(hp.foos, list)
+    assert len(hp.foos) == 3
+    foo = hp.foos[0]
+    assert isinstance(foo, Foo)
+    assert foo.baz == baz
+
+    bar = hp.foos[1]
+    assert isinstance(bar, Bar)
+    assert bar.baz == baz
+
+    foo1 = hp.foos[2]
+    assert isinstance(foo1, Foo)
+    assert foo1.baz == baz + 2
+
+
+if __name__ == "__main__":
+    baz = 1
+    data = get_data(baz, bar=True, duplicate=True)
+    cli_args = ["--foos.foo+1.baz", str(baz + 2)]
+    hp = ParentListHP.create(cli_args=cli_args, data={"foos": data})
+    assert isinstance(hp.foos, list)
+    assert len(hp.foos) == 3
+    foo = hp.foos[0]
+    assert isinstance(foo, Foo)
+    assert foo.baz == baz
+
+    bar = hp.foos[1]
+    assert isinstance(bar, Bar)
+    assert bar.baz == baz
+
+    foo1 = hp.foos[2]
+    assert isinstance(foo1, Foo)
+    assert foo1.baz == baz + 2

--- a/tests/test_yahp_list_from_yaml_dict.py
+++ b/tests/test_yahp_list_from_yaml_dict.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List
+from typing import Dict, List, Union
 
 import pytest
 
@@ -28,26 +28,22 @@ class ParentListHPNoRegistry(hp.Hparams):
 
 
 @pytest.fixture
-def baz():
+def baz() -> int:
     return 1
 
 
-@pytest.fixture
-def duplicate():
-    return False
+def get_data(baz: int, bar: bool = False, duplicate: bool = False, as_list: bool = False) -> Union[Dict, List]:
+    """Get a data dictionary
 
+    Args:
+        baz (int): Foo param
+        bar (bool, optional): Include bar? Defaults to False.
+        duplicate (bool, optional): Include foo+1?. Defaults to False.
+        as_list (bool, optional): Return the dictionary as a list. Defaults to False.
 
-@pytest.fixture
-def bar():
-    return True
-
-
-@pytest.fixture(params=(False, True))
-def as_list(request):
-    return request.param
-
-
-def get_data(baz, bar=False, duplicate=False, as_list=False):
+    Returns:
+        [type]: [description]
+    """
     d = {"foo": {"baz": baz}}
     if bar:
         d["bar"] = {"baz": baz}
@@ -58,7 +54,9 @@ def get_data(baz, bar=False, duplicate=False, as_list=False):
     return d
 
 
-def dict_to_list(data):
+def dict_to_list(data: Dict[str, Dict]) -> List[Dict]:
+    """Convert a dictionary to a list of 1-element dictionaries.
+    """
     return [{k: v} for k, v in data.items()]
 
 
@@ -210,26 +208,6 @@ def test_list_with_registry_cli_override_custom_list(baz):
 
 #@pytest.mark.xfail
 def test_list_with_registry_duplicate_cli_override(baz):
-    data = get_data(baz, bar=True, duplicate=True)
-    cli_args = ["--foos.foo+1.baz", str(baz + 2)]
-    hp = ParentListHP.create(cli_args=cli_args, data={"foos": data})
-    assert isinstance(hp.foos, list)
-    assert len(hp.foos) == 3
-    foo = hp.foos[0]
-    assert isinstance(foo, Foo)
-    assert foo.baz == baz
-
-    bar = hp.foos[1]
-    assert isinstance(bar, Bar)
-    assert bar.baz == baz
-
-    foo1 = hp.foos[2]
-    assert isinstance(foo1, Foo)
-    assert foo1.baz == baz + 2
-
-
-if __name__ == "__main__":
-    baz = 1
     data = get_data(baz, bar=True, duplicate=True)
     cli_args = ["--foos.foo+1.baz", str(baz + 2)]
     hp = ParentListHP.create(cli_args=cli_args, data={"foos": data})

--- a/yahp/create/commented_map.py
+++ b/yahp/create/commented_map.py
@@ -203,8 +203,9 @@ def to_commented_map(
                 output[f.name] = _process_abstract_hparams(cls, path_with_fname, ftype.is_list, options)
             else:
                 if ftype.is_list:
-                    output[f.name] = list_to_deduplicated_dict([{inverted_hparams[type(x)]: x.to_dict()}
-                                                                for x in ensure_tuple(default)])
+                    output[f.name] = list_to_deduplicated_dict([{
+                        inverted_hparams[type(x)]: x.to_dict()
+                    } for x in ensure_tuple(default)])
                 else:
                     output[f.name] = {inverted_hparams[type(default)]: default.to_dict()}
         if options.add_docs:

--- a/yahp/create/commented_map.py
+++ b/yahp/create/commented_map.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, List, NamedTuple, Optional, Type, get_type_hin
 
 import yahp as hp
 from yahp.utils.interactive import query_with_options
-from yahp.utils.iter_helpers import ensure_tuple
+from yahp.utils.iter_helpers import ensure_tuple, list_to_deduplicated_dict
 from yahp.utils.type_helpers import HparamsType, get_default_value, is_field_required, safe_issubclass
 
 if TYPE_CHECKING:
@@ -105,23 +105,14 @@ def _process_abstract_hparams(hparams: Type[hp.Hparams], path_with_fname: List[s
     # filter possible_sub_hparams to those in possible_keys
     possible_sub_hparams = {k: v for (k, v) in possible_sub_hparams.items() if k in possible_keys}
 
-    sub_hparams = CommentedSeq() if is_list else CommentedMap()
+    sub_hparams = CommentedMap()
     for sub_key, sub_type in possible_sub_hparams.items():
         sub_map = to_commented_map(
             cls=sub_type,
             path=list(path_with_fname) + [sub_key],
             options=options,
         )
-        if is_list:
-            sub_item = CommentedMap()
-            sub_item[sub_key] = sub_map
-            sub_hparams.append(sub_item)
-            if options.add_docs:
-                _add_commenting(sub_item,
-                                comment_key=sub_key,
-                                eol_comment=sub_type.__name__,
-                                typing_column=options.typing_column)
-            continue
+
         sub_hparams[sub_key] = sub_map
         if options.add_docs:
             _add_commenting(sub_hparams,
@@ -201,6 +192,8 @@ def to_commented_map(
                     output[f.name] = [x.to_dict() for x in ensure_tuple(default)]
                 if not ftype.is_list:
                     output[f.name] = output[f.name][0]
+                else:
+                    output[f.name] = {str(i): item for i, item in enumerate(output[f.name])}
         else:
             inverted_hparams = {v: k for (k, v) in cls.hparams_registry[f.name].items()}
             choices = [x.__name__ for x in cls.hparams_registry[f.name].values()]
@@ -210,7 +203,8 @@ def to_commented_map(
                 output[f.name] = _process_abstract_hparams(cls, path_with_fname, ftype.is_list, options)
             else:
                 if ftype.is_list:
-                    output[f.name] = [{inverted_hparams[type(x)]: x.to_dict()} for x in ensure_tuple(default)]
+                    output[f.name] = list_to_deduplicated_dict([{inverted_hparams[type(x)]: x.to_dict()}
+                                                                for x in ensure_tuple(default)])
                 else:
                     output[f.name] = {inverted_hparams[type(default)]: default.to_dict()}
         if options.add_docs:

--- a/yahp/create/create.py
+++ b/yahp/create/create.py
@@ -52,12 +52,12 @@ def _get_split_key(key: str, splitter: str = "+") -> Tuple[str, Any]:
 
     splits = key.split(splitter, 1)
     if len(splits) > 1:
-        return splits
+        return (splits[0], splits[1])
     else:
         return (splits[0], None)
 
 
-def _one_item_list_to_dict(items):
+def _one_item_list_to_dict(items: List[Any]) -> Dict[str, Any]:
     """ Converts a list of 1-item dicts to a dictionary. If the list has strings in it, they are given the value of
     None. If the list has duplicate keys, they are deduplicated by adding a '+{index}' suffix."""
 
@@ -76,6 +76,7 @@ def _one_item_list_to_dict(items):
             counter[k] = 1
         new_value[k] = v
     return new_value
+
 
 logger = logging.getLogger(__name__)
 

--- a/yahp/create/create.py
+++ b/yahp/create/create.py
@@ -266,7 +266,8 @@ def _create(
                                 raise ValueError(f"Field {full_name} is required and cannot be None.")
                             if isinstance(argparse_or_yaml_value, list):
                                 # Convert from list of single element dictionaries to dict, preserving duplicates
-                                argparse_or_yaml_value = list_to_deduplicated_dict(argparse_or_yaml_value, allow_str=True)
+                                argparse_or_yaml_value = list_to_deduplicated_dict(argparse_or_yaml_value,
+                                                                                   allow_str=True)
 
                             if not isinstance(argparse_or_yaml_value, dict):
                                 raise ValueError(f"Field {full_name} should be a dict")

--- a/yahp/hparams.py
+++ b/yahp/hparams.py
@@ -18,6 +18,7 @@ import yaml
 from yahp.create.commented_map import CMOptions, to_commented_map
 from yahp.create.create import create, get_argparse
 from yahp.utils import type_helpers
+from yahp.utils.iter_helpers import list_to_deduplicated_dict
 
 if TYPE_CHECKING:
     from yahp.types import JSON
@@ -48,7 +49,7 @@ class Hparams(ABC):
             to the concrete classes that they could be.
 
             See the :ref:`Registry Example<Registry Example>` for a walkthrough on how
-            the registry works. 
+            the registry works.
     """
 
     # note: hparams_registry cannot be typed the normal way -- dataclass reads the type annotations
@@ -167,7 +168,7 @@ class Hparams(ABC):
                             assert isinstance(x, Hparams)
                             field_name = inverted_registry[type(x)]
                             field_list.append({field_name: x.to_dict()})
-                        res[f.name] = field_list
+                        res[f.name] = list_to_deduplicated_dict(field_list)
                     else:
                         field_dict: Dict[str, JSON] = {}
                         field_name = inverted_registry[type(attr)]
@@ -177,7 +178,7 @@ class Hparams(ABC):
                 else:
                     # Specific -- either a list or not
                     if isinstance(attr, list):
-                        res[f.name] = [x.to_dict() for x in attr]
+                        res[f.name] = {str(i): x.to_dict() for i, x in enumerate(attr)}
                     else:
                         assert isinstance(attr, Hparams)
                         res[f.name] = attr.to_dict()

--- a/yahp/utils/type_helpers.py
+++ b/yahp/utils/type_helpers.py
@@ -44,7 +44,7 @@ class HparamsType:
 
     Args:
         item (type): Type annotation to parse.
-    
+
     Attributes:
         types (List[Type]): The allowed types for this annotation, as a list.
             If the annotation is ``List[X]`` or ``Optional[X]``,
@@ -296,7 +296,7 @@ def is_field_required(f: Field[Any]) -> bool:
     """
     Returns whether a field is required
     (i.e. does not have a default value).
-    
+
     Args:
         f (Field): The field.
     """
@@ -305,7 +305,7 @@ def is_field_required(f: Field[Any]) -> bool:
 
 def get_default_value(f: Field[Any]) -> Any:
     """Returns an instance of a default value for a field.
-    
+
     Args:
         f (Field): The field.
     """
@@ -318,7 +318,7 @@ def get_default_value(f: Field[Any]) -> Any:
 
 def to_bool(x: Any):
     """Converts a value to a boolean
-    
+
     Args:
         x (object): Value to attempt to convert to a bool.
     """
@@ -333,7 +333,7 @@ def to_bool(x: Any):
 
 def is_none_like(x: Any, *, allow_list: bool) -> bool:
     """Returns whether a value is ``None``, ``"none"``, ``[""]``, ``["none"]``, or has been marked as a missing field.
-    
+
     Args:
         x (object): Value to examine.
         allow_list (bool): Whether to treat ``[""]``, or ``["none"]`` as ``None``.


### PR DESCRIPTION
- Dictionaries should now be used for declaring a list of hparams
- Duplicate entries can be specified using '<field>+<unique-label>', where `<unique-label>' can be anything the user wants

TODO:
- [x] Add docstrings to tests
- [ ] Add documentation on specifying dictionaries for lists
- [ ] Add documentation on duplicate entries