### PR TITLE
[XS] Fix error message for misformatted hparams

### DIFF
--- a/yahp/hparams.py
+++ b/yahp/hparams.py
@@ -356,7 +356,7 @@ class Hparams(ABC):
             value = [value]
             for x in value:
                 if not isinstance(x, ftype.type):
-                    raise TypeError(f"{fname} must be a {ftype}; instead it is of type {type(value).__name__}")
+                    raise TypeError(f"{fname} must be a {ftype}; instead it is of type {type(x).__name__}")
                 assert isinstance(x, Hparams)
                 x.validate()
 


### PR DESCRIPTION
Got a confusing error message here today - when a singleton Hparam is expected, but something else is provided, the error message was claiming the missing piece was always a list.