### PR TITLE
Add list of dicts to inheritance

### DIFF
--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -3,11 +3,15 @@
 import os
 import pathlib
 
+import pytest
 import yaml
 
-from yahp.inheritance import preprocess_yaml_with_inheritance
+from yahp.inheritance import (_recursively_update_leaf_data_items, _unwrap_overriden_value_dict,
+                              preprocess_yaml_with_inheritance)
 
 
+# Breaks because I removed nested inherits
+# @pytest.mark.xfail
 def test_yaml_inheritance(tmpdir: pathlib.Path):
     inheritance_folder = os.path.join(os.path.dirname(__file__), "inheritance")
     input_file = os.path.join(inheritance_folder, "main.yaml")
@@ -21,4 +25,189 @@ def test_yaml_inheritance(tmpdir: pathlib.Path):
     with open(output_file, "r") as f:
         actual_output = yaml.full_load(f)
 
-    assert actual_output == expected_output
+    assert actual_output == expected_output, f"{actual_output} != {expected_output}"
+
+
+def check_update_equal(orig, target, update):
+    _recursively_update_leaf_data_items(orig, update, [])
+    _unwrap_overriden_value_dict(orig)
+    assert orig == target, f"{orig} != {target}"
+
+
+def check_update_not_equal(orig, target, update):
+    _recursively_update_leaf_data_items(orig, update, [])
+    _unwrap_overriden_value_dict(orig)
+    assert orig != target, f"{orig} == {target}"
+
+
+def test_empty_namespace():
+    orig = {}
+    target = {"a": 1, "b": {"c": 2}}
+    check_update_equal(orig, target, target)
+
+
+def test_empty_dict():
+    orig = {"a": 1, "b": {"c": 2}}
+    target = {"a": 1, "b": {"c": 2}}
+    check_update_equal(orig, target, {})
+
+
+def test_empty_nested_key():
+    orig = {"a": 1, "b": {"c": 2}}
+    target = {"a": 1, "b": {"c": 2}, "foo": {}}
+    check_update_equal(orig, target, {"foo": {}})
+
+
+def test_empty_nested_key_no_overwrite():
+    orig = {"a": 1, "b": {"c": 2}}
+    target = {"a": 1, "b": {"c": 2}}
+    update = {"b": {}}
+    check_update_equal(orig, target, update)
+
+
+# TODO: Add overwriting with None
+@pytest.mark.xfail
+def test_overwrite_simple_with_nonetype():
+    orig = {"a": 1, "b": 'foo'}
+    target = {"b": 'foo'}
+    update = {"a": None}
+    check_update_equal(orig, target, update)
+
+
+@pytest.mark.xfail
+def test_overwrite_absent_key():
+    orig = {"a": 1, "b": 'foo'}
+    target = {"a": 1, "b": 'foo'}
+    update = {"c": None}
+    check_update_equal(orig, target, update)
+
+
+@pytest.mark.xfail
+def test_overwrite_dict_with_nonetype():
+    orig = {"a": 1, "b": {"c": 2}}
+    target = {"a": 1}
+    update = {"b": None}
+    check_update_equal(orig, target, update)
+
+
+@pytest.mark.xfail
+def test_overwrite_list_with_nonetype():
+    orig = {"a": {"b": [{"c": [{"d": 'foo'}]}]}}
+    target = {"a": {}}
+    update = {"a": {"b": None}}
+    check_update_equal(orig, target, update)
+
+
+@pytest.mark.xfail
+def test_overwrite_nested_dict_with_nonetype():
+    orig = {"a": 1, "b": {"c": 2}}
+    target = {"a": 1, "b": {}}
+    update = {"b": {"c": None}}
+    check_update_equal(orig, target, update)
+
+
+@pytest.mark.xfail
+def test_overwrite_nested_list_with_nonetype():
+    orig = {"a": {"b": [{"c": [{"d": 'foo'}]}]}}
+    target = {"a": {"b": [{}]}}
+    update = {"a": {"b": {"c": None}}}
+    check_update_equal(orig, target, update)
+
+
+# @pytest.mark.xfail
+def test_update_list_of_dicts():
+    orig = {"a": [{"b": 'foo'}, {"c": 'bar'}]}
+    target = {"a": [{"b": 'baz'}, {"c": 'bar'}]}
+    update = {"a": {"b": 'baz'}}
+    check_update_equal(orig, target, update)
+
+
+def test_update_list_of_dicts_nested2():
+    orig = {"a": [{"b": {"c": 'foo'}}]}
+    target = {"a": [{"b": {"c": 'foo'}}, {"d": 'bar'}]}
+    update = {"a": {"d": "bar"}}
+    check_update_equal(orig, target, update)
+
+
+@pytest.mark.xfail
+def test_update_list_of_dicts_nested():
+    orig = {"a": [{"b": {"c": 'foo'}}, {"d": 'bar'}]}
+    target = {"a": [{"b": {"c": 'baz'}}, {"d": 'bar'}]}
+    update = {"a": {"b": {"c": 'baz'}}}
+    check_update_equal(orig, target, update)
+
+
+@pytest.mark.xfail
+def test_update_nested_list_of_dicts():
+    orig = {"a": {"b": [{"c": [{"d": 'foo'}]}]}}
+    target = {"a": {"b": [{"c": [{"d": 'bar'}]}]}}
+    update = {"a": {"b": {"c": {"d": 'bar'}}}}
+    check_update_equal(orig, target, update)
+
+
+@pytest.mark.xfail
+def test_change_data_type_simple():
+    orig = {"a": {"b": 'foo', "c": "bar"}}
+    target = {"a": {"b": 42, "c": "bar"}}
+    update = {"a": {"b": 42}}
+    check_update_equal(orig, target, update)
+
+
+@pytest.mark.xfail
+def test_change_data_type_dict():
+    orig = {"a": 1, "b": {"c": 2}}
+    target = {"a": 1, "b": "foo"}
+    update = {"b": "foo"}
+    check_update_equal(orig, target, update)
+
+
+@pytest.mark.xfail
+def test_change_data_type_list():
+    orig = {"a": {"b": [{"c": [{"d": 'foo'}]}]}}
+    target = {"a": {"b": 'foo'}}
+    update = {"a": {"b": 'foo'}}
+    check_update_equal(orig, target, update)
+
+
+@pytest.mark.xfail
+def test_change_data_type_list_nested():
+    orig = {"a": {"b": [{"c": [{"d": 'foo'}]}]}}
+    target = {"a": {"b": [{"c": 'foo'}]}}
+    update = {"a": {"b": {"c": 'foo'}}}
+    check_update_equal(orig, target, update)
+
+
+def test_nested_not_equal():
+    orig = {"a": 1, "b": {"c": 2}}
+    target = {"a": 1, "b": {"c": 3}}
+    update = {"b": {"c": 'foo'}}
+    check_update_not_equal(orig, target, update)
+
+
+def test_not_update_list():
+    orig = {"a": [0, 1, 2], "b": "foo"}
+    target = {"a": [3, 1, 2], "b": "foo"}
+    update = {"a": [3]}
+    check_update_not_equal(orig, target, update)
+
+
+@pytest.mark.xfail
+def test_docstring_example():
+    orig = {"b": {1: 1, 2: 2}}
+    target = {"b": {1: 3, 2: 2}}
+    update = {"b": {1: 3}}
+    check_update_equal(orig, target, update)
+
+
+@pytest.mark.xfail
+def test_actual_docstring_example():
+    a = {"b": {1: 1, 2: 2}}
+    _recursively_update_leaf_data_items(a, {1: 3}, ["b"])
+    assert a == {"b": {1: 3, 2: 2}}
+
+
+if __name__ == "__main__":
+    # test_yaml_inheritance("/tmp")
+    test_update_list_of_dicts_nested2()
+    # test_update_list_of_dicts_nested()
+    # test_not_update_list()

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -43,33 +43,41 @@ def check_update_not_equal(orig, target, update):
 def nested_dict():
     return {"a": {"b": {"c": 1}}}
 
+
 @pytest.fixture
 def nested_dict_none():
     return {"a": {"b": {"c": None}}}
+
 
 @pytest.fixture
 def nested_dict_overridden():
     return {"a": {"b": {"c": _OverriddenValue(1)}}}
 
+
 @pytest.fixture
 def nested_dict_inherits():
     return {"a": {"b": {"c": {"inherits": []}}}}
+
 
 @pytest.fixture
 def nested_list():
     return {"a": [{"b": {"c": 1}}]}
 
+
 @pytest.fixture
 def simple_update():
     return {"a": {"d": 'foo'}}
+
 
 @pytest.fixture
 def list_update():
     return {"a": {"d": ['foo', 'bar']}}
 
+
 @pytest.fixture
 def nested_dict_update():
     return {"a": {"d": {"e": 'foo'}}}
+
 
 @pytest.fixture
 def nested_list_update():
@@ -83,20 +91,24 @@ def test_insert_simple_nested_dict(nested_dict, simple_update):
     target["a"]["d"] = simple_update["a"]["d"]
     check_update_equal(nested_dict, target, simple_update)
 
+
 def test_insert_list_nested_dict(nested_dict, list_update):
     target = copy.deepcopy(nested_dict)
     target["a"]["d"] = list_update["a"]["d"]
     check_update_equal(nested_dict, target, list_update)
+
 
 def test_insert_nested_dict_nested_dict(nested_dict, nested_dict_update):
     target = copy.deepcopy(nested_dict)
     target["a"]["d"] = nested_dict_update["a"]["d"]
     check_update_equal(nested_dict, target, nested_dict_update)
 
+
 def test_insert_nested_list_nested_dict(nested_dict, nested_list_update):
     target = copy.deepcopy(nested_dict)
     target["a"]["d"] = nested_list_update["a"]["d"]
     check_update_equal(nested_dict, target, nested_list_update)
+
 
 ## Into nested single-item list
 def test_insert_simple_nested_list(nested_list, simple_update):
@@ -104,20 +116,24 @@ def test_insert_simple_nested_list(nested_list, simple_update):
     target["a"].append({"d": simple_update["a"]["d"]})
     check_update_equal(nested_list, target, simple_update)
 
+
 def test_insert_list_nested_list(nested_list, list_update):
     target = copy.deepcopy(nested_list)
     target["a"].append({"d": list_update["a"]["d"]})
     check_update_equal(nested_list, target, list_update)
+
 
 def test_insert_nested_dict_nested_list(nested_list, nested_dict_update):
     target = copy.deepcopy(nested_list)
     target["a"].append({"d": nested_dict_update["a"]["d"]})
     check_update_equal(nested_list, target, nested_dict_update)
 
+
 def test_insert_nested_list_nested_list(nested_list, nested_list_update):
     target = copy.deepcopy(nested_list)
     target["a"].append({"d": nested_list_update["a"]["d"]})
     check_update_equal(nested_list, target, nested_list_update)
+
 
 # Does not overwrite
 def test_no_overwrite_on_conflict_simple(nested_dict, simple_update):
@@ -126,18 +142,21 @@ def test_no_overwrite_on_conflict_simple(nested_dict, simple_update):
     conflict = {"a": {"b": {"c": simple_update["a"]["d"]}}}
     check_update_equal(nested_dict, target, conflict)
 
+
 def test_no_overwrite_on_conflict_list(nested_dict, list_update):
     target = copy.deepcopy(nested_dict)
     # Create conflict at a.b.c
     conflict = {"a": {"b": {"c": list_update["a"]["d"]}}}
     check_update_equal(nested_dict, target, conflict)
 
-@pytest.mark.xfail # TODO: Look into why this fails. Is it expected?
+
+@pytest.mark.xfail  # TODO: Look into why this fails. Is it expected?
 def test_no_overwrite_on_conflict_nested_dict(nested_dict, nested_dict_update):
     target = copy.deepcopy(nested_dict)
     # Create conflict at a.b.c
     conflict = {"a": {"b": {"c": nested_dict_update["a"]["d"]}}}
     check_update_equal(nested_dict, target, conflict)
+
 
 def test_no_overwrite_on_conflict_nested_list(nested_dict, nested_list_update):
     target = copy.deepcopy(nested_dict)
@@ -145,11 +164,13 @@ def test_no_overwrite_on_conflict_nested_list(nested_dict, nested_list_update):
     conflict = {"a": {"b": {"c": nested_list_update["a"]["d"]}}}
     check_update_equal(nested_dict, target, conflict)
 
+
 def test_no_overwrite_nested_list_on_conflict_simple(nested_list, simple_update):
     target = copy.deepcopy(nested_list)
     # Create conflict at a.b.c
     conflict = {"a": {"b": {"c": simple_update["a"]["d"]}}}
     check_update_equal(nested_list, target, conflict)
+
 
 ## Test overwrite works
 def test_overwrite_none(nested_dict_none, simple_update):
@@ -158,11 +179,13 @@ def test_overwrite_none(nested_dict_none, simple_update):
     target = copy.deepcopy(conflict)
     check_update_equal(nested_dict_none, target, conflict)
 
+
 def test_overwrite_overridden(nested_dict_overridden, simple_update):
     # Create conflict at a.b.c
     conflict = {"a": {"b": {"c": simple_update["a"]["d"]}}}
     target = copy.deepcopy(conflict)
     check_update_equal(nested_dict_overridden, target, conflict)
+
 
 def test_overwrite_inherits(nested_dict_inherits, simple_update):
     # Create conflict at a.b.c
@@ -170,26 +193,32 @@ def test_overwrite_inherits(nested_dict_inherits, simple_update):
     target = copy.deepcopy(conflict)
     check_update_equal(nested_dict_inherits, target, conflict)
 
+
 ## Test empty args
 def test_empty_namespace(simple_update):
     target = copy.deepcopy(simple_update)
     check_update_equal({}, target, simple_update)
 
+
 def test_empty_nested_namespace(simple_update):
     target = copy.deepcopy(simple_update)
     check_update_equal({"a": {}}, target, simple_update)
+
 
 def test_empty_update(nested_dict):
     target = copy.deepcopy(nested_dict)
     check_update_equal(nested_dict, target, {})
 
+
 def test_empty_nested_key(nested_dict):
     target = copy.deepcopy(nested_dict)
     check_update_equal(nested_dict, target, {"a": {}})
 
+
 def test_empty_nested_key_nested_list(nested_list):
     target = copy.deepcopy(nested_list)
     check_update_equal(nested_list, target, {"a": {}})
+
 
 ## YAML tests
 @pytest.mark.parametrize("absolute", (False, True))
@@ -215,6 +244,7 @@ def test_inheritance_absolute_path(nested_dict, simple_update, tmpdir, absolute)
     output = load_yaml_with_inheritance(base_file)
     assert output == target
 
+
 def test_inheritance_sublevel(nested_dict, simple_update, tmpdir):
     # Write update to inherits file
     inherits_file = os.path.join(tmpdir, "inherits.yaml")
@@ -235,6 +265,7 @@ def test_inheritance_sublevel(nested_dict, simple_update, tmpdir):
     target["a"]["d"] = simple_update["a"]["d"]
     output = load_yaml_with_inheritance(base_file)
     assert output == target
+
 
 def test_inheritance_second_order(nested_dict, simple_update, tmpdir):
     inherits_file_1 = os.path.join(tmpdir, "inherits1.yaml")
@@ -263,6 +294,7 @@ def test_inheritance_second_order(nested_dict, simple_update, tmpdir):
     target["a"]["d"] = simple_update["a"]["d"]
     output = load_yaml_with_inheritance(base_file)
     assert output == target
+
 
 @pytest.mark.parametrize("simple_first", (False, True))
 def test_inheritance_sort_order(nested_dict, simple_update, list_update, tmpdir, simple_first):
@@ -298,4 +330,3 @@ def test_inheritance_sort_order(nested_dict, simple_update, list_update, tmpdir,
         target["a"]["d"] = simple_update["a"]["d"]
     output = load_yaml_with_inheritance(base_file)
     assert output == target
-

--- a/tests/test_iter_helpers.py
+++ b/tests/test_iter_helpers.py
@@ -1,0 +1,65 @@
+import pytest
+
+from yahp.utils.iter_helpers import ListOfSingleItemDict
+
+
+def test_getitem():
+    x = [{"a": "foo"}, {"b": "bar"}]
+    x = ListOfSingleItemDict(x)
+
+    assert x["a"] == "foo"
+    assert x["b"] == "bar"
+
+
+def test_failed_getitem():
+    x = [{"a": "foo"}, {"b": "bar"}]
+    x = ListOfSingleItemDict(x)
+
+    with pytest.raises(TypeError):
+        _ = x["c"]
+
+
+def test_setitem_new_key():
+    x = [{"a": "foo"}, {"b": "bar"}]
+    x = ListOfSingleItemDict(x)
+    x["c"] = "baz"
+    assert "c" in x
+    assert x["c"] == "baz"
+
+
+def test_setitem_overwrite():
+    x = [{"a": "foo"}, {"b": "bar"}]
+    x = ListOfSingleItemDict(x)
+    x["b"] = "baz"
+    assert "b" in x
+    assert x["b"] == "baz"
+
+
+def test_contains():
+    x = [{"a": "foo"}, {"b": "bar"}]
+    x = ListOfSingleItemDict(x)
+
+    assert "a" in x
+    assert "b" in x
+
+
+def test_not_contains():
+    x = [{"a": "foo"}, {"b": "bar"}]
+    x = ListOfSingleItemDict(x)
+
+    assert "c" not in x
+
+
+def test_shared_memory_new_key():
+    x = [{"a": "foo"}, {"b": "bar"}]
+    y = ListOfSingleItemDict(x)
+    y["c"] = "baz"
+    assert len(x) == 3
+    assert x[2] == {"c": "baz"}
+
+
+def test_shared_memory_overwrite():
+    x = [{"a": "foo"}, {"b": "bar"}]
+    y = ListOfSingleItemDict(x)
+    y["a"] = "baz"
+    assert x[0] == {"a": "baz"}

--- a/yahp/inheritance.py
+++ b/yahp/inheritance.py
@@ -156,7 +156,8 @@ def _recursively_update_leaf_data_items(
 
         is_empty = (existing_value is None)  # Empty values should be filled in
         is_lower_priority = isinstance(existing_value, _OverriddenValue)  # Further inheritance should override previous
-        is_inherits_dict = isinstance(existing_value, dict) and "inherits" in existing_value  # Not sure about this one...
+        is_inherits_dict = isinstance(existing_value,
+                                      dict) and "inherits" in existing_value  # Not sure about this one...
 
         if is_empty or is_lower_priority or is_inherits_dict:
             inner_namespace[key] = _OverriddenValue(update_data)  # type: ignore

--- a/yahp/inheritance.py
+++ b/yahp/inheritance.py
@@ -6,7 +6,7 @@ import argparse
 import collections.abc
 import logging
 import os
-from typing import TYPE_CHECKING, Dict, List, Sequence, Tuple, Union, cast
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple, Union, cast
 
 import yaml
 
@@ -57,7 +57,7 @@ def _data_by_path(
             namespace = namespace[key]
         elif is_list_of_single_item_dicts(namespace):  #type: ignore
             assert isinstance(key, str)
-            namespace = ListOfSingleItemDict(namespace)[key]
+            namespace = ListOfSingleItemDict(namespace)[key] # type: ignore
         elif isinstance(namespace, list):
             assert isinstance(key, int)
             namespace = namespace[key]
@@ -73,13 +73,14 @@ def _ensure_path_exists(namespace: JSON, argument_path: Sequence[Union[int, str]
             namespace = namespace.setdefault(key, {})
         elif is_list_of_single_item_dicts(namespace):  #type: ignore
             assert isinstance(key, str)
-            namespace = ListOfSingleItemDict(namespace)
+            namespace = ListOfSingleItemDict(namespace) # type: ignore
             if key not in namespace:
                 namespace[key] = {}
             namespace = namespace[key]
         elif isinstance(namespace, list):
             assert isinstance(key, int)
-            namespace = namespace[key]  # TODO: try except to verify key in range
+            # TODO: try except to verify key in range
+            namespace = namespace[key] # type: ignore
         else:
             raise ValueError("Path must be empty unless if list or dict")
 
@@ -95,7 +96,7 @@ def _unwrap_overridden_value_dict(data: Dict[str, JSON]):
         if isinstance(val, collections.abc.Mapping):
             _unwrap_overridden_value_dict(val)
         elif is_list_of_single_item_dicts(val):
-            for item in val:
+            for item in val: # type: ignore
                 _unwrap_overridden_value_dict(item)
         elif isinstance(val, _OverriddenValue):
             data[key] = val.val
@@ -121,10 +122,10 @@ def _recursively_update_leaf_data_items(
 
         # Traverse the tree to the final branch
         for key in update_argument_path[:-1]:
-            key_element: JSON_NAMESPACE = None
+            key_element: Optional[ JSON_NAMESPACE ] = None
             if isinstance(inner_namespace, collections.abc.Mapping):
                 # Simple dict
-                key_element = inner_namespace.get(key)
+                key_element = inner_namespace.get(key) # type: ignore
             elif is_list_of_single_item_dicts(inner_namespace):
                 # List of single-item dicts
                 assert isinstance(inner_namespace, list)  # ensure type for pyright

--- a/yahp/inheritance.py
+++ b/yahp/inheritance.py
@@ -57,7 +57,7 @@ def _data_by_path(
             namespace = namespace[key]
         elif is_list_of_single_item_dicts(namespace):  #type: ignore
             assert isinstance(key, str)
-            namespace = ListOfSingleItemDict(namespace)[key] # type: ignore
+            namespace = ListOfSingleItemDict(namespace)[key]  # type: ignore
         elif isinstance(namespace, list):
             assert isinstance(key, int)
             namespace = namespace[key]
@@ -73,14 +73,14 @@ def _ensure_path_exists(namespace: JSON, argument_path: Sequence[Union[int, str]
             namespace = namespace.setdefault(key, {})
         elif is_list_of_single_item_dicts(namespace):  #type: ignore
             assert isinstance(key, str)
-            namespace = ListOfSingleItemDict(namespace) # type: ignore
+            namespace = ListOfSingleItemDict(namespace)  # type: ignore
             if key not in namespace:
                 namespace[key] = {}
             namespace = namespace[key]
         elif isinstance(namespace, list):
             assert isinstance(key, int)
             # TODO: try except to verify key in range
-            namespace = namespace[key] # type: ignore
+            namespace = namespace[key]  # type: ignore
         else:
             raise ValueError("Path must be empty unless if list or dict")
 
@@ -96,7 +96,7 @@ def _unwrap_overridden_value_dict(data: Dict[str, JSON]):
         if isinstance(val, collections.abc.Mapping):
             _unwrap_overridden_value_dict(val)
         elif is_list_of_single_item_dicts(val):
-            for item in val: # type: ignore
+            for item in val:  # type: ignore
                 _unwrap_overridden_value_dict(item)
         elif isinstance(val, _OverriddenValue):
             data[key] = val.val
@@ -122,10 +122,10 @@ def _recursively_update_leaf_data_items(
 
         # Traverse the tree to the final branch
         for key in update_argument_path[:-1]:
-            key_element: Optional[ JSON_NAMESPACE ] = None
+            key_element: Optional[JSON_NAMESPACE] = None
             if isinstance(inner_namespace, collections.abc.Mapping):
                 # Simple dict
-                key_element = inner_namespace.get(key) # type: ignore
+                key_element = inner_namespace.get(key)  # type: ignore
             elif is_list_of_single_item_dicts(inner_namespace):
                 # List of single-item dicts
                 assert isinstance(inner_namespace, list)  # ensure type for pyright

--- a/yahp/utils/iter_helpers.py
+++ b/yahp/utils/iter_helpers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Tuple, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Tuple, TypeVar, Union, cast
 
 if TYPE_CHECKING:
     from yahp.types import JSON


### PR DESCRIPTION
The primary purpose of this was to enable appending to a list of single-item dictionaries when using inheritance. It also does the following:

- Adds a bunch of tests
- Adds lots of comments and cleans up naming in the inheritance code to be more intuitive

@Averylamp I could use some help from you:
- with typing (there are a few remaining errors on that). 
- if you could give some thought to if the test marked "xfail" should in fact fail. I think it's right that it does, but would like your opinion
- any explanation for why [this code](https://github.com/mosaicml/yahp/blob/80b8cdb84904f6dc11703635f38f757462525a65/yahp/inheritance.py#L159) evaluating to `True` should imply that we want to override:
```
is_inherits_dict = isinstance(existing_value, dict) and "inherits" in existing_value
```
