### PR TITLE
Fix incorrect prefix for missing key error message

### DIFF
--- a/yahp/create/create.py
+++ b/yahp/create/create.py
@@ -340,13 +340,12 @@ def _create(
             # TODO parse args from
             sub_hparams: List[hp.Hparams] = []
             for create_call in ensure_tuple(create_calls):
-                prefix = create_call.prefix
                 if create_call.parser_args is None:
                     parsed_arg_dict = {}
                 else:
                     parser = argparse.ArgumentParser(add_help=False)
                     argparsers.append(parser)
-                    group = parser.add_argument_group(title=".".join(prefix),
+                    group = parser.add_argument_group(title=".".join(create_call.prefix),
                                                       description=create_call.hparams_cls.__name__)
                     for args in create_call.parser_args:
                         for arg in ensure_tuple(args):
@@ -359,7 +358,7 @@ def _create(
                         data=create_call.data,
                         parsed_args=parsed_arg_dict,
                         cli_args=cli_args,
-                        prefix=prefix,
+                        prefix=create_call.prefix,
                         argparse_name_registry=argparse_name_registry,
                         argparsers=argparsers,
                     ))
@@ -438,6 +437,7 @@ def create(
                                          argparsers=argparsers)
     except _MissingRequiredFieldException as e:
         _add_help(argparsers, remaining_cli_args)
+        print(e.args)
         raise ValueError("The following required fields were not included in the yaml nor the CLI arguments: "
                          f"{', '.join(e.args)}") from e
     _add_help(argparsers, remaining_cli_args)

--- a/yahp/create/create.py
+++ b/yahp/create/create.py
@@ -437,7 +437,6 @@ def create(
                                          argparsers=argparsers)
     except _MissingRequiredFieldException as e:
         _add_help(argparsers, remaining_cli_args)
-        print(e.args)
         raise ValueError("The following required fields were not included in the yaml nor the CLI arguments: "
                          f"{', '.join(e.args)}") from e
     _add_help(argparsers, remaining_cli_args)


### PR DESCRIPTION
Occasionally, when a key was missing from a YAHP, the error message would print the key with an invalid prefix. This was due to the `prefix` variable being overwritten in the `_create` function.

For example, giving something like `{ foo: { x: 1 } }` where something like `{ foo: { x: 1 }, y: 2 }` was expected would give an error message stating that `foo.y` was missing.