### PR TITLE
Fix pyright; env overrides

### DIFF
--- a/.github/actions/pyright/action.yaml
+++ b/.github/actions/pyright/action.yaml
@@ -11,7 +11,7 @@ runs:
       working-directory: ${{ inputs.working_directory }}
       run: |
         set -ex
-        sudo npm install -g pyright
+        sudo npm install -g pyright@1.1.206
 
     - name: Run Pyright
       shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,20 +16,36 @@ exclude = [
     "build/**",
 ]
 
-reportUnknownMemberType = "none"
-reportImportCycles = "none"
-reportUnnecessaryIsInstance = "none"
+reportUnnecessaryIsInstance = "warning"
 reportMissingTypeStubs = "none"
 reportIncompatibleMethodOverride = "warning"
-reportIncompatibleVariableOverride = "warning"
+reportIncompatibleVariableOverride = "error"
 reportUnusedImport = "error"
-reportMissingModuleSource = "none"
+reportUnusedClass = "warning"
+reportUnusedFunction = "warning"
+reportUnusedVariable = "error"
+reportDuplicateImport = "error"
+reportWildcardImportFromLibrary = "error"
+reportUntypedFunctionDecorator = "warning"
 reportPrivateImportUsage = "warning"
 reportUndefinedVariable = "error"
-reportMissingImports = "error"
-
-pythonVersion = "3.8"
-pythonPlatform = "Linux"
+strictParameterNoneValue = true
+reportPropertyTypeMismatch = "error"
+reportUntypedNamedTuple = "error"
+reportUnnecessaryCast = "error"
+reportInvalidTypeVarUse = "error"
+reportOverlappingOverload = "error"
+reportUninitializedInstanceVariable = "error"
+reportInvalidStringEscapeSequence = "error"
+reportMissingParameterType = "warning"  # TODO: make this an error
+reportCallInDefaultInitializer = "none"  # TODO: make this an error
+reportUnnecessaryComparison = "warning"
+reportSelfClsParameterName = "error"
+reportImplicitStringConcatenation = "warning"  # TODO: make this an error
+reportInvalidStubStatement = "error"
+reportIncompleteStub = "error"
+reportUnsupportedDunderAll = "error"
+reportUnusedCoroutine = "error"
 
 # Pytest
 [tool.pytest.ini_options]

--- a/tests/test_yahp_register.py
+++ b/tests/test_yahp_register.py
@@ -1,6 +1,6 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
 
-from typing import Dict, cast
+from typing import Dict
 
 import pytest
 
@@ -18,16 +18,13 @@ def test_register_new_hparam_choice(choice_one_yaml_input: YamlInput):
 
     root_hparams_data: Dict[str, JSON] = {"choice": {"one": choice_one_yaml_input.dict_data}}
 
-    choice_one_hparam = cast(ChoiceHparamRoot, ChoiceHparamRoot.create(data=root_hparams_data))
+    choice_one_hparam = ChoiceHparamRoot.create(data=root_hparams_data)
     # Check that existing hparams still work
     assert isinstance(choice_one_hparam.choice, ChoiceOneHparam)
 
     # Check that new registered hparams can be created
     root_hparams_data["choice"] = {"empty": None}
-    choice_empty: ChoiceHparamRoot = cast(
-        ChoiceHparamRoot,
-        ChoiceHparamRoot.create(data=root_hparams_data),
-    )
+    choice_empty = ChoiceHparamRoot.create(data=root_hparams_data)
 
     assert isinstance(choice_empty.choice, EmptyHparam)
 

--- a/tests/yahp_fixtures.py
+++ b/tests/yahp_fixtures.py
@@ -1,5 +1,6 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
 
+import pathlib
 import textwrap
 from dataclasses import dataclass
 from enum import Enum, IntEnum
@@ -33,13 +34,13 @@ class EnumStringField(Enum):
 # Helpers
 # -------------------------------------------------
 @pytest.fixture
-def hparams_tempdir(tmp_path):
+def hparams_tempdir(tmp_path: pathlib.Path):
     d = tmp_path / "hparams"
     d.mkdir()
     return d
 
 
-def generate_named_tuple_from_str(hparams_tempdir, input_str: str, filepath: str):
+def generate_named_tuple_from_str(hparams_tempdir: pathlib.Path, input_str: str, filepath: str):
     input_data = yaml.full_load(input_str)
     f = hparams_tempdir / filepath
     f.write_text(input_str)
@@ -47,7 +48,7 @@ def generate_named_tuple_from_str(hparams_tempdir, input_str: str, filepath: str
     return out
 
 
-def generate_named_tuple_from_data(hparams_tempdir, input_data: Dict[str, Any], filepath: str):
+def generate_named_tuple_from_data(hparams_tempdir: pathlib.Path, input_data: Dict[str, Any], filepath: str):
     input_str = yaml.dump(input_data)
     f = hparams_tempdir / filepath
     f.write_text(input_str)
@@ -109,7 +110,7 @@ class PrimitiveHparam(hp.Hparams):
 
 
 @pytest.fixture
-def primitive_yaml_input(hparams_tempdir) -> YamlInput:
+def primitive_yaml_input(hparams_tempdir: pathlib.Path) -> YamlInput:
     primitive_hparams_input_str = textwrap.dedent("""
     ---
     intfield: 1
@@ -164,7 +165,7 @@ class NestedHparam(hp.Hparams):
 
 
 @pytest.fixture
-def nested_yaml_input(hparams_tempdir, primitive_yaml_input: YamlInput) -> YamlInput:
+def nested_yaml_input(hparams_tempdir: pathlib.Path, primitive_yaml_input: YamlInput) -> YamlInput:
     return generate_named_tuple_from_data(
         hparams_tempdir=hparams_tempdir,
         input_data={
@@ -195,7 +196,7 @@ class DoubleNestedHparam(hp.Hparams):
 
 
 @pytest.fixture
-def double_nested_yaml_input(hparams_tempdir, nested_yaml_input: YamlInput) -> YamlInput:
+def double_nested_yaml_input(hparams_tempdir: pathlib.Path, nested_yaml_input: YamlInput) -> YamlInput:
     return generate_named_tuple_from_data(
         hparams_tempdir=hparams_tempdir,
         input_data={
@@ -235,7 +236,7 @@ class ChoiceOneHparam(ChoiceHparamParent):
 
 
 @pytest.fixture
-def choice_one_yaml_input(hparams_tempdir) -> YamlInput:
+def choice_one_yaml_input(hparams_tempdir: pathlib.Path) -> YamlInput:
     input_str = textwrap.dedent("""
     ---
     commonfield: true
@@ -269,7 +270,7 @@ class ChoiceTwoHparam(ChoiceHparamParent):
 
 
 @pytest.fixture
-def choice_two_yaml_input(hparams_tempdir, primitive_yaml_input: YamlInput) -> YamlInput:
+def choice_two_yaml_input(hparams_tempdir: pathlib.Path, primitive_yaml_input: YamlInput) -> YamlInput:
     data = {
         "primitive_hparam": primitive_yaml_input.dict_data,
         "commonfield": False,
@@ -309,7 +310,7 @@ class ChoiceThreeHparam(ChoiceHparamParent):
 
 
 @pytest.fixture
-def choice_three_two_yaml_input(hparams_tempdir, choice_two_yaml_input: YamlInput) -> YamlInput:
+def choice_three_two_yaml_input(hparams_tempdir: pathlib.Path, choice_two_yaml_input: YamlInput) -> YamlInput:
     data = {
         "choice": {
             "two": choice_two_yaml_input.dict_data
@@ -325,7 +326,7 @@ def choice_three_two_yaml_input(hparams_tempdir, choice_two_yaml_input: YamlInpu
 
 
 @pytest.fixture
-def choice_three_one_yaml_input(hparams_tempdir, choice_one_yaml_input: YamlInput) -> YamlInput:
+def choice_three_one_yaml_input(hparams_tempdir: pathlib.Path, choice_one_yaml_input: YamlInput) -> YamlInput:
     data = {
         "choice": {
             "one": choice_one_yaml_input.dict_data
@@ -400,7 +401,7 @@ class OptionalFieldHparam(hp.Hparams):
 
 
 @pytest.fixture
-def optional_field_empty_object_yaml_input(hparams_tempdir) -> YamlInput:
+def optional_field_empty_object_yaml_input(hparams_tempdir: pathlib.Path) -> YamlInput:
     data = {"choice": {"one": {}}}
     return generate_named_tuple_from_data(hparams_tempdir=hparams_tempdir,
                                           input_data=data,
@@ -408,7 +409,7 @@ def optional_field_empty_object_yaml_input(hparams_tempdir) -> YamlInput:
 
 
 @pytest.fixture
-def optional_field_null_object_yaml_input(hparams_tempdir) -> YamlInput:
+def optional_field_null_object_yaml_input(hparams_tempdir: pathlib.Path) -> YamlInput:
     data = {"choice": {"one": None}}
     return generate_named_tuple_from_data(hparams_tempdir=hparams_tempdir,
                                           input_data=data,
@@ -429,7 +430,7 @@ class ListHparam(hp.Hparams):
 
 
 @pytest.fixture
-def empty_object_yaml_input(hparams_tempdir) -> YamlInput:
+def empty_object_yaml_input(hparams_tempdir: pathlib.Path) -> YamlInput:
     return generate_named_tuple_from_data(hparams_tempdir=hparams_tempdir, input_data={}, filepath="empty_object.yaml")
 
 

--- a/yahp/create/argparse.py
+++ b/yahp/create/argparse.py
@@ -231,6 +231,7 @@ def retrieve_args(
                 inverted_field_registry = {v: k for (k, v) in cls.hparams_registry[f.name].items()}
                 default = inverted_field_registry[type(default)]
 
+        nargs = None
         if not ftype.is_hparams_dataclass:
             nargs = None
             if ftype.is_list:
@@ -239,6 +240,7 @@ def retrieve_args(
                 nargs = "?"
             choices = None
             if ftype.is_enum:
+                assert issubclass(ftype.type, Enum)
                 choices = [x.name.lower() for x in ftype.type]
             if ftype.is_boolean and len(ftype.types) == 1:
                 choices = ["true", "false"]

--- a/yahp/create/commented_map.py
+++ b/yahp/create/commented_map.py
@@ -181,6 +181,7 @@ def to_commented_map(
             elif ftype.is_list:
                 output[f.name] = CommentedSeq()
                 if ftype.is_enum:
+                    assert issubclass(ftype.type, Enum)
                     # If an enum list, then put all enum options in the list
                     output[f.name].extend([x.name for x in ftype.type])
             else:
@@ -192,6 +193,7 @@ def to_commented_map(
                 output[f.name] = None
             else:
                 if default == MISSING:
+                    assert issubclass(ftype.type, hp.Hparams)
                     output[f.name] = [(to_commented_map(
                         cls=ftype.type,
                         path=path_with_fname,

--- a/yahp/create/create.py
+++ b/yahp/create/create.py
@@ -7,6 +7,7 @@ import logging
 import os
 import pathlib
 import sys
+import textwrap
 import warnings
 from dataclasses import MISSING, dataclass, fields
 from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, TextIO, Tuple, Type, TypeVar, Union, get_type_hints
@@ -95,15 +96,16 @@ def _create(
         try:
             ftype = HparamsType(field_types[f.name])
             full_name = ".".join(prefix_with_fname)
+            env_name = full_name.upper().replace(".", "_")  # dots are not (easily) allowed in env variables
             if full_name in parsed_args and parsed_args[full_name] != MISSING:
                 # use CLI args first
                 argparse_or_yaml_value = parsed_args[full_name]
             elif f.name in data:
                 # then use YAML
                 argparse_or_yaml_value = data[f.name]
-            elif full_name.upper() in os.environ:
+            elif env_name in os.environ:
                 # then use environment variables
-                argparse_or_yaml_value = os.environ[full_name.upper()]
+                argparse_or_yaml_value = os.environ[env_name]
             else:
                 # otherwise, set it as MISSING so the default will be used
                 argparse_or_yaml_value = MISSING
@@ -136,6 +138,7 @@ def _create(
                                 sub_yaml = {}
                             if not isinstance(sub_yaml, dict):
                                 raise ValueError(f"{full_name} must be a dict in the yaml")
+                            assert issubclass(ftype.type, hp.Hparams)
                             deferred_create_calls[f.name] = _DeferredCreateCall(
                                 hparams_cls=ftype.type,
                                 data=sub_yaml,
@@ -168,6 +171,7 @@ def _create(
                                     sub_yaml_item = {}
                                 if not isinstance(sub_yaml_item, dict):
                                     raise TypeError(f"{full_name} must be a dict in the yaml")
+                                assert issubclass(ftype.type, hp.Hparams)
                                 deferred_calls.append(
                                     _DeferredCreateCall(
                                         hparams_cls=ftype.type,
@@ -293,8 +297,9 @@ def _create(
                                 if key_yaml is None:
                                     key_yaml = {}
                                 if not isinstance(key_yaml, dict):
-                                    raise ValueError(f"Field {'.'.join(prefix_with_fname + [key])}"
-                                                     "must be a dict if specified in the yaml")
+                                    raise ValueError(
+                                        textwrap.dedent(f"""Field {'.'.join(prefix_with_fname + [key])}
+                                        must be a dict if specified in the yaml"""))
                                 deferred_calls.append(
                                     _DeferredCreateCall(
                                         hparams_cls=cls.hparams_registry[f.name][key],
@@ -437,8 +442,10 @@ def create(
                                          argparsers=argparsers)
     except _MissingRequiredFieldException as e:
         _add_help(argparsers, remaining_cli_args)
-        raise ValueError("The following required fields were not included in the yaml nor the CLI arguments: "
-                         f"{', '.join(e.args)}") from e
+        missing_fields = f"{', '.join(e.args)}"
+        raise ValueError(
+            textwrap.dedent(f"""The following required fields were not included in the yaml nor the CLI arguments:
+            {missing_fields}""")) from e
     _add_help(argparsers, remaining_cli_args)
 
     # Only if successful, warn for extra cli arguments
@@ -498,8 +505,9 @@ def _get_hparams(
 
     if f is not None:
         if data is not None:
-            raise ValueError("Since a hparams file was specified via "
-                             f"{'function arguments' if cli_f is None else 'the CLI'}, `data` must be None.")
+            raise ValueError(
+                textwrap.dedent(f"""Since a hparams file was specified via
+                {'function arguments' if cli_f is None else 'the CLI'}, `data` must be None."""))
         if isinstance(f, pathlib.PurePath):
             f = str(f)
         if isinstance(f, str):

--- a/yahp/field.py
+++ b/yahp/field.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import MISSING, field
-from typing import Any, Callable, overload
+from dataclasses import _MISSING_TYPE, MISSING, field
+from typing import Any, Callable, Union, overload
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +19,7 @@ def required(doc: str, *, template_default: Any) -> Any:
     ...
 
 
-def required(doc: str, *, template_default=MISSING):
+def required(doc: str, *, template_default: Any = MISSING):
     """
     A required field for a :class:`~yahp.hparams.Hparams`.
 
@@ -47,7 +47,7 @@ def optional(doc: str, *, default_factory: Callable[[], Any]) -> Any:
     ...
 
 
-def optional(doc: str, *, default=MISSING, default_factory=MISSING):
+def optional(doc: str, *, default: Any = MISSING, default_factory: Union[_MISSING_TYPE, Callable[[], Any]] = MISSING):
     """
     An optional field for a :class:`yahp.hparams.Hparams`.
 

--- a/yahp/hparams.py
+++ b/yahp/hparams.py
@@ -204,8 +204,9 @@ class Hparams(ABC):
             The initialized object.
         """
         del args, kwargs
-        raise NotImplementedError("Initializing object not supported for this Hparams. "
-                                  "To enable, add initialize_object method.")
+        raise NotImplementedError(
+            textwrap.dedent("""Initializing object not supported for this Hparams.
+            To enable, add initialize_object method."""))
 
     @classmethod
     def dump(
@@ -298,9 +299,9 @@ class Hparams(ABC):
         sub_registry = cls.hparams_registry[field]
         existing_keys = sub_registry.keys()
         if class_key in existing_keys:
-            raise ValueError(f"Field {class_key}.{field} already registered in the {cls.__name__} "
-                             f"registry for class: {sub_registry[field]}. \n"
-                             f"Make sure you register new classes with a unique name")
+            raise ValueError(
+                textwrap.dedent(f"""Field {class_key}.{field} already registered in the {cls.__name__}
+                "registry for class: {sub_registry[field]}. Make sure you register new classes with a unique name"""))
 
         logger.info(f"Successfully registered: {register_class.__name__} for key: {class_key} in {cls.__name__}")
         sub_registry[class_key] = register_class
@@ -356,7 +357,7 @@ class Hparams(ABC):
             value = [value]
             for x in value:
                 if not isinstance(x, ftype.type):
-                    raise TypeError(f"{fname} must be a {ftype}; instead it is of type {type(value).__name__}")
+                    raise TypeError(f"{fname} must be a {ftype}; instead it is of type {type(x).__name__}")
                 assert isinstance(x, Hparams)
                 x.validate()
 

--- a/yahp/inheritance.py
+++ b/yahp/inheritance.py
@@ -178,7 +178,7 @@ def load_yaml_with_inheritance(yaml_path: str) -> Dict[str, JSON]:
             sub_yaml_data = load_yaml_with_inheritance(yaml_path=sub_yaml_path)
             try:
                 sub_data = _data_by_path(namespace=sub_yaml_data, argument_path=arg_path_parts)
-            except KeyError as e:
+            except KeyError:
                 logger.warn(f"Failed to load item from inherited sub_yaml: {sub_yaml_path}")
                 continue
             _recursively_update_leaf_data_items(

--- a/yahp/utils/type_helpers.py
+++ b/yahp/utils/type_helpers.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from dataclasses import MISSING, Field
 from enum import Enum
-from typing import Any, Sequence, Tuple, Type, Union
+from typing import Any, Dict, Sequence, Tuple, Type, Union, cast
 
 import yahp as hp
 from yahp.utils.iter_helpers import ensure_tuple
@@ -89,7 +89,7 @@ class HparamsType:
             is_list = False
             return [item], is_optional, is_list
         if origin is Union:
-            args = get_args(item)
+            args = cast(Sequence[Any], get_args(item))
             is_optional = type(None) in args
             args_without_none = tuple(arg for arg in args if arg not in (None, type(None)))
             # all args in the union must be subclasses of one of the following subsets
@@ -136,7 +136,7 @@ class HparamsType:
                 raise error
             return [list_item]
         if list_origin is Union:
-            list_args = get_args(list_item)
+            list_args = cast(Sequence[Any], get_args(list_item))
             is_primitive = _is_valid_primitive(*list_args)
             if not is_primitive:
                 raise error
@@ -194,7 +194,8 @@ class HparamsType:
                 raise TypeError(f"{field_name} is a list, but wrap_singletons is false")
         if self.is_enum:
             # could be a list of enums too
-            enum_map = {k.name.lower(): k for k in self.type}
+            assert issubclass(self.type, Enum)
+            enum_map: Dict[Union[str, Enum], Enum] = {k.name.lower(): k for k in self.type}
             enum_map.update({k.value: k for k in self.type})
             enum_map.update({k: k for k in self.type})
             if isinstance(val, str):  # if the val is a string, then check for a key match
@@ -271,6 +272,7 @@ class HparamsType:
                 ans = self.type.__name__
 
         if self.is_enum:
+            assert issubclass(self.type, Enum)
             enum_values_string = ", ".join([x.name for x in self.type])
             ans = f"{self.type.__name__}{{{enum_values_string}}}"
 
@@ -332,13 +334,13 @@ def to_bool(x: Any):
 
 
 def is_none_like(x: Any, *, allow_list: bool) -> bool:
-    """Returns whether a value is ``None``, ``"none"``, ``[""]``, or ``["none"]``
+    """Returns whether a value is MISSING, ``None``, ``"none"``, ``[""]``, or ``["none"]``
     
     Args:
         x (object): Value to examine.
         allow_list (bool): Whether to treat ``[""]``, or ``["none"]`` as ``None``.
     """
-    if x is None:
+    if x is None or x is MISSING:
         return True
     if isinstance(x, str) and x.lower() in ["", "none"]:
         return True

--- a/yahp/utils/typing_future.py
+++ b/yahp/utils/typing_future.py
@@ -1,6 +1,7 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
 
 # pyright: reportUnusedImport=none
+# pyright: reportMissingParameterType=none
 
 # Future functions from typing for compatibility with python 3.7
 


### PR DESCRIPTION
1. Updated pyright to 1.1.206; fixed type issues
2. Updated yahp with the pyright config from composer
3. Fixed an issue with env variable loading: Replacing periods with underscores, since periods are not (easily) allowed in env variable names.