### PR TITLE
Implicitly enable optional parent class with specified child field

### DIFF
--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -60,8 +60,9 @@ def test_get_helpless_argpars():
 
 def test_optional_required_hparams_only_child():
     args = ['--optional_child.required_field', '5']
-    with pytest.raises(ValueError):
-        o = OptionalRequiredParentHparam.create(cli_args=args)
+    o = OptionalRequiredParentHparam.create(cli_args=args)
+    assert o.optional_child is not None
+    assert o.optional_child.required_field == 5
     
 def test_optional_required_hparams_both():
     args = ['--optional_child', '5', '--optional_child.required_field', '5']

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -2,8 +2,7 @@
 
 import pytest
 
-from tests.yahp_fixtures import (ListHparam, OptionalBooleansHparam, YamlInput,
-                                 OptionalRequiredParentHparam)
+from tests.yahp_fixtures import (ListHparam, OptionalBooleansHparam, YamlInput, OptionalRequiredParentHparam)
 
 
 def test_boolean_overrides_explicit(empty_object_yaml_input: YamlInput):
@@ -58,12 +57,14 @@ def test_get_helpless_argpars():
     with pytest.raises(SystemExit):
         parser.parse_args("--help")
 
+
 def test_optional_required_hparams_only_child():
     args = ['--optional_child.required_field', '5']
     o = OptionalRequiredParentHparam.create(cli_args=args)
     assert o.optional_child is not None
     assert o.optional_child.required_field == 5
-    
+
+
 def test_optional_required_hparams_both():
     args = ['--optional_child', '5', '--optional_child.required_field', '5']
     o = OptionalRequiredParentHparam.create(cli_args=args)

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -2,7 +2,8 @@
 
 import pytest
 
-from tests.yahp_fixtures import ListHparam, OptionalBooleansHparam, YamlInput
+from tests.yahp_fixtures import (ListHparam, OptionalBooleansHparam, YamlInput,
+                                 OptionalRequiredParentHparam)
 
 
 def test_boolean_overrides_explicit(empty_object_yaml_input: YamlInput):
@@ -56,3 +57,14 @@ def test_get_helpless_argpars():
     assert namespace.default_false == 'true'
     with pytest.raises(SystemExit):
         parser.parse_args("--help")
+
+def test_optional_required_hparams_only_child():
+    args = ['--optional_child.required_field', '5']
+    with pytest.raises(ValueError):
+        o = OptionalRequiredParentHparam.create(cli_args=args)
+    
+def test_optional_required_hparams_both():
+    args = ['--optional_child', '5', '--optional_child.required_field', '5']
+    o = OptionalRequiredParentHparam.create(cli_args=args)
+    assert o.optional_child is not None
+    assert o.optional_child.required_field == 5

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -66,7 +66,7 @@ def test_optional_required_hparams_only_child():
 
 
 def test_optional_required_hparams_both():
-    args = ['--optional_child', '5', '--optional_child.required_field', '5']
+    args = ['--optional_child', '_dummy_value', '--optional_child.required_field', '5']
     o = OptionalRequiredParentHparam.create(cli_args=args)
     assert o.optional_child is not None
     assert o.optional_child.required_field == 5

--- a/yahp/create/argparse.py
+++ b/yahp/create/argparse.py
@@ -202,7 +202,7 @@ def retrieve_args(
     prefix: List[str],
     argparse_name_registry: ArgparseNameRegistry,
 ) -> Sequence[ParserArgument]:
-    # Retreive argparse args for the class. Does NOT recruse.
+    # Retrieve argparse args for the class. Does NOT recurse.
     field_types = get_type_hints(cls)
     ans: List[ParserArgument] = []
     for f in fields(cls):

--- a/yahp/create/create.py
+++ b/yahp/create/create.py
@@ -125,8 +125,14 @@ def _create(
                     # potentially none
                     if not ftype.is_list:
                         # concrete, singleton hparams
-                        # potentially none
-                        if ftype.is_optional and is_none_like(argparse_or_yaml_value, allow_list=ftype.is_list):
+                        # potentially none. If cli args specify a child field, implicitly enable optional parent class
+                        is_none = ftype.is_optional and is_none_like(argparse_or_yaml_value, allow_list=ftype.is_list)
+                        if is_none:
+                            for cli_arg in cli_args:
+                                if cli_arg.lstrip('-').startswith(f.name):
+                                    is_none = False
+                                    break
+                        if is_none:
                             # none
                             kwargs[f.name] = None
                         else:
@@ -511,6 +517,7 @@ def _get_hparams(
     if not isinstance(data, dict):
         raise TypeError("`data` must be a dict or None")
 
+    # Parse args based on class cdefinition
     main_args = retrieve_args(cls=cls, prefix=[], argparse_name_registry=argparse_name_registry)
     parser = argparse.ArgumentParser(add_help=False)
     argparsers.append(parser)


### PR DESCRIPTION
Resolves issue https://github.com/mosaicml/yahp/issues/101. Now, when a child field for an optional parent class is specified, the parent class is automatically enabled