### PR TITLE
Fix yapf

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ extra_deps["dev"] = {
     'junitparser>=2.1.1',
     'coverage[toml]>=5.5',
     'pytest>=6.2.0',
+    'toml>=0.10.2',
     'yapf>=0.13.0',
     'isort>=5.9.3',
     'bump2version>=1.0.1',


### PR DESCRIPTION
Seems like yapf is missing a requirement 

From https://github.com/mosaicml/yahp/pull/104:
https://github.com/mosaicml/yahp/runs/5117354346?check_suite_focus=true

![image](https://user-images.githubusercontent.com/17102158/153090648-1fc44fd7-d94e-408d-af8d-03afcc70e7a7.png)
