### PR TITLE
Added noarch: python

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -15,6 +15,7 @@ channels:
 
 build:
   number: 0
+  noarch: python
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
@@ -41,7 +42,9 @@ test:
     - pytest
 
 about:
-  home: https://github.com/mosaicml/yahp
+  home: https://www.mosaicml.com
   license: Apache 2.0
   license_file: LICENSE
+  summary: "Yet Another HyperParameter Framework"
+  dev_url: https://github.com/mosaicml/yahp
   doc_url: https://docs.mosaicml.com/projects/yahp/en/stable/


### PR DESCRIPTION
Noarch is needed so conda builds irrespective of python or platform version