### PR TITLE
fix default help output

### DIFF
--- a/yahp/create/argparse.py
+++ b/yahp/create/argparse.py
@@ -218,9 +218,9 @@ def retrieve_args(
         if required:
             helptext = f'(required): {helptext}'
         if default != MISSING:
-            if default is None or safe_issubclass(default, (int, float, str, Enum)):
+            if default is None or safe_issubclass(type(default), (int, float, str, Enum)):
                 helptext = f"{helptext} (Default: {default})."
-            elif safe_issubclass(default, hp.Hparams):
+            elif safe_issubclass(type(default), hp.Hparams):
                 helptext = f"{helptext} (Default: {type(default).__name__})."
 
         # Assumes that if a field default is supposed to be None it will not appear in the namespace


### PR DESCRIPTION
Previously, when running --help from composer (i.e. ```python examples/run_composer_trainer.py --help```, it would only print out the default values when the default was None. With this fix, we print out the default values as long as the default type is a subclass of int, float, str, or Enum. 

This error was caused by function calls to [```safe_issubclass()```](https://github.com/mosaicml/yahp/blob/47326c39df9dcc64dcb62071f62898bb52105b21/yahp/utils/type_helpers.py#L22) with the parameter ```default``` instead of ```type(default``` (```safe_issubclass()``` operates on types).

Example of Previous Behavior:
```
--profiler_trace_file PROFILER_TRACE_FILE
                        <Optional[str]> Name of the trace file, relative to the run directory. Must be specified to
                        activate the profiler. (Default: None).
  --prof_event_handlers [{json} [{json} ...]]
                        <List[ProfilerEventHandlerHparams]> Trace event handler. Ignored if `profiler_trace_file`
                        is not specified.
  --prof_skip_first PROF_SKIP_FIRST
                        <int> Number of batches to skip at epoch start. Ignored if `profiler_trace_file` is not
                        specified.
  --prof_wait PROF_WAIT
                        <int> Number of batches to skip at the beginning of each cycle. Ignored if
                        `profiler_trace_file` is not specified.
  --prof_warmup PROF_WARMUP
                        <int> Number of warmup batches in a cycle. Ignored if `profiler_trace_file` is not
                        specified.
```

New Behavior:
```
  --profiler_trace_file PROFILER_TRACE_FILE
                        <Optional[str]> Name of the trace file, relative to the run directory. Must be specified to
                        activate the profiler. (Default: None).
  --prof_event_handlers [{json} [{json} ...]]
                        <List[ProfilerEventHandlerHparams]> Trace event handler. Ignored if `profiler_trace_file`
                        is not specified.
  --prof_skip_first PROF_SKIP_FIRST
                        <int> Number of batches to skip at epoch start. Ignored if `profiler_trace_file` is not
                        specified. (Default: 0).
  --prof_wait PROF_WAIT
                        <int> Number of batches to skip at the beginning of each cycle. Ignored if
                        `profiler_trace_file` is not specified. (Default: 0).
  --prof_warmup PROF_WARMUP
                        <int> Number of warmup batches in a cycle. Ignored if `profiler_trace_file` is not
                        specified. (Default: 1).
```