### PR TITLE
`hp.auto`: Create YAHP fields from the docstring and init signatures

### DIFF
--- a/.github/actions/doctest/action.yaml
+++ b/.github/actions/doctest/action.yaml
@@ -1,0 +1,18 @@
+name: Doctest
+inputs:
+  working_directory:
+    required: true
+    description: Directory containing the Makefile
+runs:
+  using: composite
+  steps:
+    - name: Run doctests
+      shell: bash
+      working-directory: ${{ inputs.working_directory }}
+      run: |
+        set -exuo pipefail
+
+        cd docs
+        make clean
+        make html
+        make doctest

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -37,3 +37,6 @@ jobs:
       - uses: ./.github/actions/pytest
         with:
           working_directory: ${{ github.workspace }}
+      - uses: ./.github/actions/doctest
+        with:
+          working_directory: ${{ github.workspace }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
         language: node
         types: [python]
         pass_filenames: false
-        additional_dependencies: ["pyright"]
+        additional_dependencies: ["pyright@1.1.243"]
 # -   repo: https://github.com/PyCQA/pydocstyle
 #     hooks:
 #     -   id: pydocstyle

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-    python: python3.8
+    python: python3
 repos:
 -   repo: https://github.com/google/yapf
     rev: v0.32.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,6 +30,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.extlinks',
     'sphinx.ext.coverage',
+    'sphinx.ext.doctest',
     'sphinx.ext.napoleon',
     'sphinxcontrib.katex',
     'sphinx.ext.viewcode',

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,7 @@ with open('README.md', 'r', encoding='utf-8') as fh:
 
 exec(open('yahp/version.py', 'r', encoding='utf-8').read())
 
-install_requires = [
-    'PyYAML>=5.4.1',
-    'ruamel.yaml>=0.17.10',
-]
+install_requires = ['PyYAML>=5.4.1', 'ruamel.yaml>=0.17.10', 'docstring_parser>=0.14.1,<=0.15']
 
 extra_deps = {}
 

--- a/tests/test_auto_field.py
+++ b/tests/test_auto_field.py
@@ -1,0 +1,65 @@
+from typing import Callable
+from unittest.mock import Mock
+
+import pytest
+
+import yahp as hp
+import yahp.field
+
+
+class FooClassDocstring:
+    """Foo class
+
+    Args:
+        required (str): Required parameter.
+        optional (int, optional): Optional parameter. (default: ``5``)
+    """
+
+    def __init__(self, required: str, optional: int = 5):
+        self.required = required
+        self.optional = optional
+
+
+class FooClassAndInitDocstring:
+    """Foo class.
+    """
+
+    def __init__(self, required: str, optional: int = 5):
+        """Foo init.
+
+        Args:
+            required (str): Required parameter.
+            optional (int, optional): Optional parameter. (default: ``5``)
+        """
+        self.required = required
+        self.optional = optional
+
+
+def foo_func(required: str, optional: int = 5):
+    """Foo func.
+
+    Args:
+        required (str): Required parameter.
+        optional (int, optional): Optional parameter. (default: ``5``)
+    """
+    del required, optional  # unused
+
+
+@pytest.mark.parametrize('constructor', [FooClassDocstring, FooClassAndInitDocstring, foo_func])
+class TestHpAuto:
+
+    def test_required(self, constructor: Callable, monkeypatch: pytest.MonkeyPatch):
+        mock = Mock()
+        mock.return_value = 'MOCK_RETURN'
+        monkeypatch.setattr(yahp.field, 'required', mock)
+        field = hp.auto(constructor, 'required')
+        mock.assert_called_once_with('Required parameter.')
+        assert field == mock.return_value
+
+    def test_optional(self, constructor: Callable, monkeypatch: pytest.MonkeyPatch):
+        mock = Mock()
+        mock.return_value = 'MOCK_RETURN'
+        monkeypatch.setattr(yahp.field, 'optional', mock)
+        field = hp.auto(constructor, 'optional')
+        mock.assert_called_once_with('Optional parameter. (default: ``5``)', default=5)
+        assert field == mock.return_value

--- a/yahp/__init__.py
+++ b/yahp/__init__.py
@@ -1,7 +1,13 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
 
-from yahp.field import optional as optional
-from yahp.field import required as required
-from yahp.hparams import Hparams as Hparams
+from yahp.field import auto, optional, required
+from yahp.hparams import Hparams
 
 from .version import __version__
+
+__all__ = [
+    'optional',
+    'required',
+    'auto',
+    'Hparams',
+]

--- a/yahp/create/create.py
+++ b/yahp/create/create.py
@@ -141,7 +141,9 @@ def _create(
                         # potentially none. If cli args specify a child field, implicitly enable optional parent class
                         is_none = ftype.is_optional and is_none_like(argparse_or_yaml_value, allow_list=ftype.is_list)
                         if is_none and cli_args is not None:
-                            for cli_arg in cli_args:
+                            # Likely pyright bug; hence the type ignore below
+                            # Object of type "None" cannot be used as iterable value (reportOptionalIterable)
+                            for cli_arg in cli_args:  # type: ignore
                                 if cli_arg.lstrip('-').startswith(f.name):
                                     is_none = False
                                     break

--- a/yahp/field.py
+++ b/yahp/field.py
@@ -136,7 +136,7 @@ def auto(constructor: Callable, arg_name: str):
         if param.arg_name == arg_name:
             doc = param.description
     if doc is None:
-        raise ValueError(f'{constructor} does not contain a docstring entry ')
+        raise ValueError(f'{constructor.__name__} does not contain a docstring entry for argument {arg_name}')
 
     if parameter.default == inspect.Parameter.empty:
         return required(doc)

--- a/yahp/field.py
+++ b/yahp/field.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import inspect
 import logging
 from dataclasses import _MISSING_TYPE, MISSING, field
 from typing import Any, Callable, Union, overload
 
+import docstring_parser
+
 logger = logging.getLogger(__name__)
+
+__all__ = ['required', 'optional', 'auto']
 
 
 @overload
@@ -74,3 +79,66 @@ def optional(doc: str, *, default: Any = MISSING, default_factory: Union[_MISSIN
         default=default,
         default_factory=default_factory,
     )
+
+
+def auto(constructor: Callable, arg_name: str):
+    """A field automatically inferred from the docstring and signature.
+
+    This helper will automatically parse the docstring and signature of a class or function to determine
+    the documentation entry and default value for a field.
+
+    For example:
+
+    .. testcode::
+
+        import dataclasses
+        import yahp as hp
+
+        class Foo:
+            '''Foo.
+
+            Args:
+                bar (str): Required parameter.
+                baz (int, optional): Optional parameter.
+            '''
+
+            def __init__(self, bar: str, baz: int = 42):
+                self.bar = bar
+                self.baz = baz
+
+        @dataclasses.dataclass
+        class FooHparams(hp.Hparams):
+            bar: str = hp.auto(Foo, 'bar')  # Equivalent to hp.required(doc='Required parameter.')
+            baz: int = hp.auto(Foo, 'baz')  # Equivalent to hp.optional(doc='Optional parameter.', default=42)
+
+    Args:
+        cls (Callable): The class or function.
+        arg_name (str): The argument name within the class or function signature and docstring.
+
+    Returns:
+        A yahp field.
+    """
+    sig = inspect.signature(constructor)
+    parameter = sig.parameters[arg_name]
+
+    # Extract the documentation from the docstring
+    docstring = constructor.__doc__
+    if type(constructor) == type and constructor.__init__.__doc__ is not None:
+        # If `constructor` is a class, then the docstring may be under `__init__`
+        docstring = constructor.__init__.__doc__
+
+    if docstring is None:
+        raise ValueError(f'{constructor.__name__} does not have a docstring')
+    parsed_docstring = docstring_parser.parse(docstring)
+    docstring_params = parsed_docstring.params
+    doc = None
+    for param in docstring_params:
+        if param.arg_name == arg_name:
+            doc = param.description
+    if doc is None:
+        raise ValueError(f'{constructor} does not contain a docstring entry ')
+
+    if parameter.default == inspect.Parameter.empty:
+        return required(doc)
+    else:
+        return optional(doc, default=parameter.default)


### PR DESCRIPTION
1. Added `hp.auto` to automatically create a yahp field from the docstring
2. Added in doctests
3. Updated the pre-commit-config to work on python 3.10

Closes #97 