### PR TITLE
Parse str last

### DIFF
--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -8,7 +8,7 @@ import pytest
 import yahp as hp
 
 
-@pytest.mark.parametrize('val,expected', [('1', '1'), ('1ep', '1ep'), (2, 2)])
+@pytest.mark.parametrize('val,expected', [('1', 1), ('1ep', '1ep'), (2, 2)])
 def test_union(val: Union[str, int], expected: Union[str, int]):
 
     @dataclass

--- a/yahp/utils/type_helpers.py
+++ b/yahp/utils/type_helpers.py
@@ -228,8 +228,10 @@ class HparamsType:
                 return None
         if not self.is_optional and val is None:
             raise ValueError(f'{field_name} is None, but a value is required.')
-        if any(isinstance(val, t) for t in self.types):
+
+        if any(isinstance(val, t) for t in self.types if t != str):
             # It is already a valid type
+            # unless a str (types such as Union[str, int] should try to coerce to int first)
             return val
         if self.is_list:
             # If given a list, then return a list of converted values


### PR DESCRIPTION
Hparams such as `grad_accum: Optional[str, int]` should attempt to use `int` first before defaulting to `str`. Otherwise, argparse flags such as `--grad_accum 1` would be converted as a string, instead of an int. 