### PR TITLE
JSON Schema Support

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - python >=3.7
     - pyyaml >=5.4.1
     - ruamel.yaml >=0.17.10
+    - jsonschema >=4.7.2
 
 test:
   requires:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,9 @@ with open('README.md', 'r', encoding='utf-8') as fh:
 
 exec(open('yahp/version.py', 'r', encoding='utf-8').read())
 
-install_requires = ['PyYAML>=5.4.1', 'ruamel.yaml>=0.17.10', 'docstring_parser>=0.14.1,<=0.15', 'jsonschema>=4.7.2,<4.8']
+install_requires = [
+    'PyYAML>=5.4.1', 'ruamel.yaml>=0.17.10', 'docstring_parser>=0.14.1,<=0.15', 'jsonschema>=4.7.2,<4.8'
+]
 
 extra_deps = {}
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md', 'r', encoding='utf-8') as fh:
 
 exec(open('yahp/version.py', 'r', encoding='utf-8').read())
 
-install_requires = ['PyYAML>=5.4.1', 'ruamel.yaml>=0.17.10', 'docstring_parser>=0.14.1,<=0.15']
+install_requires = ['PyYAML>=5.4.1', 'ruamel.yaml>=0.17.10', 'docstring_parser>=0.14.1,<=0.15', 'jsonschema>=4.7.2']
 
 extra_deps = {}
 

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6,6 +6,7 @@ import textwrap
 from typing import Type
 
 import pytest
+import yaml
 from jsonschema import ValidationError
 
 from tests.yahp_fixtures import (BearsHparams, ChoiceHparamParent, KitchenSinkHparams, PrimitiveHparam,
@@ -73,6 +74,51 @@ from yahp.hparams import Hparams
                       sub_dict_item: 43
         """)
     ],
+    [
+        KitchenSinkHparams,
+        True,
+        textwrap.dedent("""
+            ---
+            required_int_field: 1
+            nullable_required_int_field:
+            required_bool_field: False
+            nullable_required_bool_field:
+            required_enum_field_list:
+                - RED
+                - red
+            required_enum_field_with_default: green
+            nullable_required_enum_field: None
+            nullable_required_enum_field:
+            required_union_bool_str_field: hi
+            nullable_required_union_bool_str_field:
+            required_int_list_field:
+                - 1
+                - 2
+                - 42
+            nullable_required_list_int_field:
+                - 24
+            nullable_required_list_union_bool_str_field:
+            required_list_union_bool_str_field:
+                - True
+                - hi
+                - False
+                - bye
+            required_subhparams_field: { default_false: False, default_true: True }
+            nullable_required_subhparams_field:
+            required_subhparams_field_list:
+                - { default_false: False }
+                - {}
+            nullable_required_subhparams_field_list:
+            required_choice:
+                one:
+                    commonfield: True
+                    intfield: 3
+            nullable_required_choice:
+            required_choice_list: []
+            nullable_required_choice_list:
+            optional_float_field_default_1: 1.1
+        """),
+    ],
     [ChoiceHparamParent, True,
      textwrap.dedent("""
             ---
@@ -133,10 +179,9 @@ from yahp.hparams import Hparams
         """)
     ],
 ])
-def test_validate_json_schema_from_data(hparam_class: Type[Hparams], success: bool, data: str):
-    print(json.dumps(hparam_class.get_json_schema(), indent=4))
+def test_validate_json_schema_from_strings(hparam_class: Type[Hparams], success: bool, data: str):
     with contextlib.nullcontext() if success else pytest.raises(ValidationError):
-        hparam_class.validate_yaml(data=data)
+        hparam_class.validate_yaml(data=yaml.safe_load(data))
 
 
 @pytest.mark.parametrize('hparam_class,success,file', [
@@ -179,11 +224,3 @@ def test_write_and_read_json_schema_from_file(hparam_class: Type[Hparams], tmp_p
         loaded_schema = json.load(f)
     generated_schema = hparam_class.get_json_schema()
     assert loaded_schema == generated_schema
-
-
-# @pytest.mark.parametrize('hparam_class', [
-#     KitchenSinkHparams,
-# ])
-# def test_write_and_read_json_schema_from_file2(hparam_class: Type[Hparams], tmp_path: pathlib.Path):
-#     print(json.dumps(hparam_class.get_json_schema(), indent=4))
-#     assert False

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -8,7 +8,8 @@ from typing import Type
 import pytest
 from jsonschema import ValidationError
 
-from tests.yahp_fixtures import ChoiceHparamParent, KitchenSinkHparams, PrimitiveHparam, ShavingBearsHparam
+from tests.yahp_fixtures import (BearsHparams, ChoiceHparamParent, KitchenSinkHparams, PrimitiveHparam,
+                                 ShavingBearsHparam)
 from yahp.hparams import Hparams
 
 
@@ -94,8 +95,46 @@ from yahp.hparams import Hparams
                 other_random_field: "cool"
         """)
     ],
+    [BearsHparams, True, textwrap.dedent("""
+            ---
+            bears:
+        """)],
+    [
+        BearsHparams, True,
+        textwrap.dedent("""
+            ---
+            bears:
+                - shaved_bears:
+                    first_action: "Procure bears"
+                    last_action: "Release bears into wild with stylish new haircuts"
+        """)
+    ],
+    [
+        BearsHparams, True,
+        textwrap.dedent("""
+            ---
+            bears:
+                - unshaved_bears:
+                    second_action: "Procure bears"
+                    third_action: "Release bears into wild with stylish new haircuts"
+        """)
+    ],
+    [
+        BearsHparams, True,
+        textwrap.dedent("""
+            ---
+            bears:
+                - shaved_bears:
+                    first_action: "Procure bears"
+                    last_action: "Release bears into wild with stylish new haircuts"
+                - unshaved_bears:
+                    second_action: "Procure bears"
+                    third_action: "Release bears into wild with stylish new haircuts"
+        """)
+    ],
 ])
 def test_validate_json_schema_from_data(hparam_class: Type[Hparams], success: bool, data: str):
+    print(json.dumps(hparam_class.get_json_schema(), indent=4))
     with contextlib.nullcontext() if success else pytest.raises(ValidationError):
         hparam_class.validate_yaml(data=data)
 
@@ -114,6 +153,7 @@ def test_validate_json_schema_from_file(hparam_class: Type[Hparams], success: bo
     ChoiceHparamParent,
     PrimitiveHparam,
     KitchenSinkHparams,
+    BearsHparams,
 ])
 def test_write_and_read_json_schema_from_name(hparam_class: Type[Hparams], tmp_path: pathlib.Path):
     file = os.path.join(tmp_path, 'schema.json')
@@ -129,6 +169,7 @@ def test_write_and_read_json_schema_from_name(hparam_class: Type[Hparams], tmp_p
     ChoiceHparamParent,
     PrimitiveHparam,
     KitchenSinkHparams,
+    BearsHparams,
 ])
 def test_write_and_read_json_schema_from_file(hparam_class: Type[Hparams], tmp_path: pathlib.Path):
     file = os.path.join(tmp_path, 'schema.json')
@@ -139,3 +180,10 @@ def test_write_and_read_json_schema_from_file(hparam_class: Type[Hparams], tmp_p
     generated_schema = hparam_class.get_json_schema()
     assert loaded_schema == generated_schema
 
+
+# @pytest.mark.parametrize('hparam_class', [
+#     KitchenSinkHparams,
+# ])
+# def test_write_and_read_json_schema_from_file2(hparam_class: Type[Hparams], tmp_path: pathlib.Path):
+#     print(json.dumps(hparam_class.get_json_schema(), indent=4))
+#     assert False

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -84,6 +84,7 @@ from yahp.hparams import Hparams
         """)],
 ])
 def test_validate_json_schema_from_data(hparam_class: Type[Hparams], success: bool, data: str):
+    print(json.dumps(hparam_class.get_json_schema(), indent=4))
     with contextlib.nullcontext() if success else pytest.raises(ValidationError):
         hparam_class.validate_yaml(data=data)
 
@@ -128,3 +129,9 @@ def test_write_and_read_json_schema_from_file(hparam_class: Type[Hparams], tmp_p
     assert loaded_schema == generated_schema
 
 
+# @pytest.mark.parametrize('hparam_class', [
+#     KitchenSinkHparams,
+# ])
+# def test_write_and_read_json_schema_from_file2(hparam_class: Type[Hparams], tmp_path: pathlib.Path):
+#     print(json.dumps(hparam_class.get_json_schema(), indent=4))
+#     assert False

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1,13 +1,14 @@
+import contextlib
 import json
 import os
-import tempfile
+import pathlib
 import textwrap
 from typing import Type
 
 import pytest
 from jsonschema import ValidationError
 
-from tests.yahp_fixtures import ChoiceHparamParent, PrimitiveHparam, ShavingBearsHparam
+from tests.yahp_fixtures import ChoiceHparamParent, KitchenSinkHparams, PrimitiveHparam, ShavingBearsHparam
 from yahp.hparams import Hparams
 
 
@@ -21,7 +22,7 @@ from yahp.hparams import Hparams
             floatfield: 0.5
             boolfield: true
             enumintfield: ONE
-            enumstringfield: pytorch_lightning
+            enumstringfield: mosaic
             jsonfield:
                 empty_item: {}
                 random_item: 1
@@ -50,7 +51,7 @@ from yahp.hparams import Hparams
             floatfield: 0.5
             boolfield: true
             enumintfield: ONE
-            enumstringfield: pytorch_lightning
+            enumstringfield: mosaic
             jsonfield:
                 empty_item: {}
                 random_item: 1
@@ -83,11 +84,8 @@ from yahp.hparams import Hparams
         """)],
 ])
 def test_validate_json_schema_from_data(hparam_class: Type[Hparams], success: bool, data: str):
-    if success:
+    with contextlib.nullcontext() if success else pytest.raises(ValidationError):
         hparam_class.validate_yaml(data=data)
-    else:
-        with pytest.raises(ValidationError):
-            hparam_class.validate_yaml(data=data)
 
 
 @pytest.mark.parametrize('hparam_class,success,file', [
@@ -95,11 +93,24 @@ def test_validate_json_schema_from_data(hparam_class: Type[Hparams], success: bo
      os.path.join(os.path.dirname(__file__), 'inheritance/shaving_bears.yaml')],
 ])
 def test_validate_json_schema_from_file(hparam_class: Type[Hparams], success: bool, file: str):
-    if success:
+    print(json.dumps(hparam_class.get_json_schema(), indent=4))
+    with contextlib.nullcontext() if success else pytest.raises(ValidationError):
         hparam_class.validate_yaml(f=file)
-    else:
-        with pytest.raises(ValidationError):
-            hparam_class.validate_yaml(f=file)
+
+
+@pytest.mark.parametrize('hparam_class', [
+    ShavingBearsHparam,
+    ChoiceHparamParent,
+    PrimitiveHparam,
+    KitchenSinkHparams,
+])
+def test_write_and_read_json_schema_from_name(hparam_class: Type[Hparams], tmp_path: pathlib.Path):
+    file = os.path.join(tmp_path, 'schema.json')
+    hparam_class.dump_jsonschema(file)
+    with open(file) as f:
+        loaded_schema = json.load(f)
+    generated_schema = hparam_class.get_json_schema()
+    assert loaded_schema == generated_schema
 
 
 @pytest.mark.parametrize('hparam_class', [
@@ -107,27 +118,13 @@ def test_validate_json_schema_from_file(hparam_class: Type[Hparams], success: bo
     ChoiceHparamParent,
     PrimitiveHparam,
 ])
-def test_write_and_read_json_schema_from_name(hparam_class: Type[Hparams]):
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        file = os.path.join(tmpdirname, 'schema.json')
-        hparam_class.dump_jsonschema(file)
-        with open(file) as f:
-            loaded_schema = json.load(f)
-        generated_schema = hparam_class.get_json_schema()
-        assert loaded_schema == generated_schema
+def test_write_and_read_json_schema_from_file(hparam_class: Type[Hparams], tmp_path: pathlib.Path):
+    file = os.path.join(tmp_path, 'schema.json')
+    with open(file, 'w') as f:
+        hparam_class.dump_jsonschema(f)
+    with open(file) as f:
+        loaded_schema = json.load(f)
+    generated_schema = hparam_class.get_json_schema()
+    assert loaded_schema == generated_schema
 
 
-@pytest.mark.parametrize('hparam_class', [
-    ShavingBearsHparam,
-    ChoiceHparamParent,
-    PrimitiveHparam,
-])
-def test_write_and_read_json_schema_from_file(hparam_class: Type[Hparams]):
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        file = os.path.join(tmpdirname, 'schema.json')
-        with open(file, 'w') as f:
-            hparam_class.dump_jsonschema(f)
-        with open(file) as f:
-            loaded_schema = json.load(f)
-        generated_schema = hparam_class.get_json_schema()
-        assert loaded_schema == generated_schema

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -82,9 +82,20 @@ from yahp.hparams import Hparams
             ---
             commonfield: 1
         """)],
+    [
+        ShavingBearsHparam, True,
+        textwrap.dedent("""
+            ---
+            parameters:
+                random_field:
+                shaved_bears:
+                    first_action: "Procure bears"
+                    last_action: "Release bears into wild with stylish new haircuts"
+                other_random_field: "cool"
+        """)
+    ],
 ])
 def test_validate_json_schema_from_data(hparam_class: Type[Hparams], success: bool, data: str):
-    print(json.dumps(hparam_class.get_json_schema(), indent=4))
     with contextlib.nullcontext() if success else pytest.raises(ValidationError):
         hparam_class.validate_yaml(data=data)
 
@@ -94,7 +105,6 @@ def test_validate_json_schema_from_data(hparam_class: Type[Hparams], success: bo
      os.path.join(os.path.dirname(__file__), 'inheritance/shaving_bears.yaml')],
 ])
 def test_validate_json_schema_from_file(hparam_class: Type[Hparams], success: bool, file: str):
-    print(json.dumps(hparam_class.get_json_schema(), indent=4))
     with contextlib.nullcontext() if success else pytest.raises(ValidationError):
         hparam_class.validate_yaml(f=file)
 
@@ -118,6 +128,7 @@ def test_write_and_read_json_schema_from_name(hparam_class: Type[Hparams], tmp_p
     ShavingBearsHparam,
     ChoiceHparamParent,
     PrimitiveHparam,
+    KitchenSinkHparams,
 ])
 def test_write_and_read_json_schema_from_file(hparam_class: Type[Hparams], tmp_path: pathlib.Path):
     file = os.path.join(tmp_path, 'schema.json')
@@ -128,10 +139,3 @@ def test_write_and_read_json_schema_from_file(hparam_class: Type[Hparams], tmp_p
     generated_schema = hparam_class.get_json_schema()
     assert loaded_schema == generated_schema
 
-
-# @pytest.mark.parametrize('hparam_class', [
-#     KitchenSinkHparams,
-# ])
-# def test_write_and_read_json_schema_from_file2(hparam_class: Type[Hparams], tmp_path: pathlib.Path):
-#     print(json.dumps(hparam_class.get_json_schema(), indent=4))
-#     assert False

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1,0 +1,109 @@
+import os
+import pytest
+import textwrap
+import tempfile
+from typing import Type
+from jsonschema import ValidationError
+import json
+
+from tests.yahp_fixtures import PrimitiveHparam, ChoiceHparamParent, ShavingBearsHparam
+
+from yahp.hparams import Hparams
+
+@pytest.mark.parametrize('hparam_class,success,data', 
+    [
+        [PrimitiveHparam, True, textwrap.dedent("""
+            ---
+            intfield: 1
+            strfield: hello
+            floatfield: 0.5
+            boolfield: true
+            enumintfield: ONE
+            enumstringfield: pytorch_lightning
+            jsonfield:
+                empty_item: {}
+                random_item: 1
+                random_item2: two
+                random_item3: true
+                random_item4: 0.1
+                random_subdict:
+                    random_subdict_item5: 12
+                    random_subdict_item6: 1337
+                random_list:
+                    - 1
+                    - 3
+                    - 99
+                random_list_of_dict:
+                    - sub_dict: 12
+                      sub_dict_item: 1
+                    - sub_dict2: 14
+                      sub_dict_item: 43
+        """)],
+        [PrimitiveHparam, False, textwrap.dedent("""
+            ---
+            strfield: hello
+            floatfield: 0.5
+            boolfield: true
+            enumintfield: ONE
+            enumstringfield: pytorch_lightning
+            jsonfield:
+                empty_item: {}
+                random_item: 1
+                random_item2: two
+                random_item3: true
+                random_item4: 0.1
+                random_subdict:
+                    random_subdict_item5: 12
+                    random_subdict_item6: 1337
+                random_list:
+                    - 1
+                    - 3
+                    - 99
+                random_list_of_dict:
+                    - sub_dict: 12
+                      sub_dict_item: 1
+                    - sub_dict2: 14
+                      sub_dict_item: 43
+        """)],
+        [ChoiceHparamParent, True, textwrap.dedent("""
+            ---
+            commonfield: True
+        """)],
+        [ChoiceHparamParent, False, textwrap.dedent("""
+            ---
+            commonfield: 1
+        """)],
+    ]
+)
+def test_validate_json_schema_from_data(hparam_class: Type[Hparams], success: bool, data: str):
+    if success:
+        hparam_class.validate_yaml(data=data)
+    else:
+        with pytest.raises(ValidationError):
+            hparam_class.validate_yaml(data=data)
+
+@pytest.mark.parametrize('hparam_class,success', 
+    [
+        [ShavingBearsHparam, True],
+    ]
+)
+def test_validate_json_schema_from_file(hparam_class: Type[Hparams], success: bool):
+    print(json.dumps(hparam_class.get_json_schema(), sort_keys=False, indent=4))
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        shaving_bears = textwrap.dedent("""
+        ---
+        parameters:
+            random_field: 12
+            shaved_bears:
+                first_action: "Procure bears"
+                last_action: "Release bears into wild with stylish new haircuts"
+            other_random_field: "cool"
+        """)
+        filename = os.path.join(tmpdirname, "shaving_bears.yaml")
+        with open(filename, 'w') as f:
+            f.write(shaving_bears)
+        if success:
+            hparam_class.validate_yaml(f=filename)
+        else:
+            with pytest.raises(ValidationError):
+                hparam_class.validate_yaml(f=filename)

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1,4 +1,6 @@
+import json
 import os
+import tempfile
 import textwrap
 from typing import Type
 
@@ -92,9 +94,40 @@ def test_validate_json_schema_from_data(hparam_class: Type[Hparams], success: bo
     [ShavingBearsHparam, True,
      os.path.join(os.path.dirname(__file__), 'inheritance/shaving_bears.yaml')],
 ])
-def test_validate_json_schema_from_file2(hparam_class: Type[Hparams], success: bool, file: str):
+def test_validate_json_schema_from_file(hparam_class: Type[Hparams], success: bool, file: str):
     if success:
         hparam_class.validate_yaml(f=file)
     else:
         with pytest.raises(ValidationError):
             hparam_class.validate_yaml(f=file)
+
+
+@pytest.mark.parametrize('hparam_class', [
+    ShavingBearsHparam,
+    ChoiceHparamParent,
+    PrimitiveHparam,
+])
+def test_write_and_read_json_schema_from_name(hparam_class: Type[Hparams]):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        file = os.path.join(tmpdirname, 'schema.json')
+        hparam_class.dump_jsonschema(file)
+        with open(file) as f:
+            loaded_schema = json.load(f)
+        generated_schema = hparam_class.get_json_schema()
+        assert loaded_schema == generated_schema
+
+
+@pytest.mark.parametrize('hparam_class', [
+    ShavingBearsHparam,
+    ChoiceHparamParent,
+    PrimitiveHparam,
+])
+def test_write_and_read_json_schema_from_file(hparam_class: Type[Hparams]):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        file = os.path.join(tmpdirname, 'schema.json')
+        with open(file, 'w') as f:
+            hparam_class.dump_jsonschema(f)
+        with open(file) as f:
+            loaded_schema = json.load(f)
+        generated_schema = hparam_class.get_json_schema()
+        assert loaded_schema == generated_schema

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1,18 +1,18 @@
 import os
-import pytest
 import textwrap
-import tempfile
 from typing import Type
+
+import pytest
 from jsonschema import ValidationError
-import json
 
-from tests.yahp_fixtures import PrimitiveHparam, ChoiceHparamParent, ShavingBearsHparam
-
+from tests.yahp_fixtures import ChoiceHparamParent, PrimitiveHparam, ShavingBearsHparam
 from yahp.hparams import Hparams
 
-@pytest.mark.parametrize('hparam_class,success,data', 
+
+@pytest.mark.parametrize('hparam_class,success,data', [
     [
-        [PrimitiveHparam, True, textwrap.dedent("""
+        PrimitiveHparam, True,
+        textwrap.dedent("""
             ---
             intfield: 1
             strfield: hello
@@ -38,8 +38,11 @@ from yahp.hparams import Hparams
                       sub_dict_item: 1
                     - sub_dict2: 14
                       sub_dict_item: 43
-        """)],
-        [PrimitiveHparam, False, textwrap.dedent("""
+        """)
+    ],
+    [
+        PrimitiveHparam, False,
+        textwrap.dedent("""
             ---
             strfield: hello
             floatfield: 0.5
@@ -64,17 +67,19 @@ from yahp.hparams import Hparams
                       sub_dict_item: 1
                     - sub_dict2: 14
                       sub_dict_item: 43
-        """)],
-        [ChoiceHparamParent, True, textwrap.dedent("""
+        """)
+    ],
+    [ChoiceHparamParent, True,
+     textwrap.dedent("""
             ---
             commonfield: True
         """)],
-        [ChoiceHparamParent, False, textwrap.dedent("""
+    [ChoiceHparamParent, False,
+     textwrap.dedent("""
             ---
             commonfield: 1
         """)],
-    ]
-)
+])
 def test_validate_json_schema_from_data(hparam_class: Type[Hparams], success: bool, data: str):
     if success:
         hparam_class.validate_yaml(data=data)
@@ -82,28 +87,14 @@ def test_validate_json_schema_from_data(hparam_class: Type[Hparams], success: bo
         with pytest.raises(ValidationError):
             hparam_class.validate_yaml(data=data)
 
-@pytest.mark.parametrize('hparam_class,success', 
-    [
-        [ShavingBearsHparam, True],
-    ]
-)
-def test_validate_json_schema_from_file(hparam_class: Type[Hparams], success: bool):
-    print(json.dumps(hparam_class.get_json_schema(), sort_keys=False, indent=4))
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        shaving_bears = textwrap.dedent("""
-        ---
-        parameters:
-            random_field: 12
-            shaved_bears:
-                first_action: "Procure bears"
-                last_action: "Release bears into wild with stylish new haircuts"
-            other_random_field: "cool"
-        """)
-        filename = os.path.join(tmpdirname, "shaving_bears.yaml")
-        with open(filename, 'w') as f:
-            f.write(shaving_bears)
-        if success:
-            hparam_class.validate_yaml(f=filename)
-        else:
-            with pytest.raises(ValidationError):
-                hparam_class.validate_yaml(f=filename)
+
+@pytest.mark.parametrize('hparam_class,success,file', [
+    [ShavingBearsHparam, True,
+     os.path.join(os.path.dirname(__file__), 'inheritance/shaving_bears.yaml')],
+])
+def test_validate_json_schema_from_file2(hparam_class: Type[Hparams], success: bool, file: str):
+    if success:
+        hparam_class.validate_yaml(f=file)
+    else:
+        with pytest.raises(ValidationError):
+            hparam_class.validate_yaml(f=file)

--- a/tests/yahp_fixtures.py
+++ b/tests/yahp_fixtures.py
@@ -606,7 +606,7 @@ class ShavedBearsHparam(hp.Hparams):
 
 @dataclass
 class ParametersHparam(hp.Hparams):
-    random_field: int = hp.required(doc='int field')
+    random_field: Optional[int] = hp.required(doc='int field')
     shaved_bears: ShavedBearsHparam = hp.required(doc='ShavedBears Hparams')
     other_random_field: str = hp.required(doc='str field')
 

--- a/tests/yahp_fixtures.py
+++ b/tests/yahp_fixtures.py
@@ -592,6 +592,7 @@ def optional_required_yaml_input(hparams_tempdir) -> YamlInput:
                                           input_data=data,
                                           filepath='optional_required.yaml')
 
+
 @dataclass
 class ShavedBearsHparam(hp.Hparams):
     first_action: str = hp.required(doc='str field')
@@ -601,6 +602,7 @@ class ShavedBearsHparam(hp.Hparams):
         assert isinstance(self.first_action, str)
         assert isinstance(self.last_action, str)
         super().validate()
+
 
 @dataclass
 class ParametersHparam(hp.Hparams):
@@ -614,6 +616,7 @@ class ParametersHparam(hp.Hparams):
         self.shaved_bears.validate()
         assert isinstance(self.other_random_field, str)
         super().validate()
+
 
 @dataclass
 class ShavingBearsHparam(hp.Hparams):

--- a/tests/yahp_fixtures.py
+++ b/tests/yahp_fixtures.py
@@ -4,12 +4,13 @@ import pathlib
 import textwrap
 from dataclasses import dataclass
 from enum import Enum, IntEnum
-from typing import Any, Dict, List, NamedTuple, Optional, Union, cast
+from typing import Any, Dict, List, NamedTuple, Optional, Type, Union, cast
 
 import pytest
 import yaml
 
 import yahp as hp
+from yahp.hparams import Hparams
 from yahp.types import JSON
 
 
@@ -605,6 +606,17 @@ class ShavedBearsHparam(hp.Hparams):
 
 
 @dataclass
+class UnshavedBearsHparam(hp.Hparams):
+    second_action: str = hp.required(doc='str field')
+    third_action: str = hp.required(doc='str field')
+
+    def validate(self):
+        assert isinstance(self.second_action, str)
+        assert isinstance(self.third_action, str)
+        super().validate()
+
+
+@dataclass
 class ParametersHparam(hp.Hparams):
     random_field: Optional[int] = hp.required(doc='int field')
     shaved_bears: ShavedBearsHparam = hp.required(doc='ShavedBears Hparams')
@@ -626,3 +638,19 @@ class ShavingBearsHparam(hp.Hparams):
         assert isinstance(self.parameters, ParametersHparam)
         self.parameters.validate()
         super().validate()
+
+
+bears_registry: Dict[str, Type[hp.Hparams]] = {
+    'shaved_bears': ShavedBearsHparam,
+    'unshaved_bears': UnshavedBearsHparam,
+}
+
+
+@dataclass
+class BearsHparams(hp.Hparams):
+
+    hparams_registry = {
+        'bears': bears_registry,
+    }
+
+    bears: Optional[List[Hparams]] = hp.required(doc='bear field')

--- a/tests/yahp_fixtures.py
+++ b/tests/yahp_fixtures.py
@@ -591,3 +591,35 @@ def optional_required_yaml_input(hparams_tempdir) -> YamlInput:
     return generate_named_tuple_from_data(hparams_tempdir=hparams_tempdir,
                                           input_data=data,
                                           filepath='optional_required.yaml')
+
+@dataclass
+class ShavedBearsHparam(hp.Hparams):
+    first_action: str = hp.required(doc='str field')
+    last_action: str = hp.required(doc='str field')
+
+    def validate(self):
+        assert isinstance(self.first_action, str)
+        assert isinstance(self.last_action, str)
+        super().validate()
+
+@dataclass
+class ParametersHparam(hp.Hparams):
+    random_field: int = hp.required(doc='int field')
+    shaved_bears: ShavedBearsHparam = hp.required(doc='ShavedBears Hparams')
+    other_random_field: str = hp.required(doc='str field')
+
+    def validate(self):
+        assert isinstance(self.random_field, int)
+        assert isinstance(self.shaved_bears, ParametersHparam)
+        self.shaved_bears.validate()
+        assert isinstance(self.other_random_field, str)
+        super().validate()
+
+@dataclass
+class ShavingBearsHparam(hp.Hparams):
+    parameters: ParametersHparam = hp.required(doc='Parameters Hparams')
+
+    def validate(self):
+        assert isinstance(self.parameters, ParametersHparam)
+        self.parameters.validate()
+        super().validate()

--- a/tests/yahp_fixtures.py
+++ b/tests/yahp_fixtures.py
@@ -118,7 +118,7 @@ def primitive_yaml_input(hparams_tempdir: pathlib.Path) -> YamlInput:
     floatfield: 0.5
     boolfield: true
     enumintfield: ONE
-    enumstringfield: pytorch_lightning
+    enumstringfield: mosaic
     jsonfield:
       empty_item: {}
       random_item: 1

--- a/yahp/create_object/argparse.py
+++ b/yahp/create_object/argparse.py
@@ -120,7 +120,7 @@ def get_hparams_file_from_cli(
 ) -> Tuple[Optional[str], Optional[str], Optional[str]]:
     parser = argparse.ArgumentParser(add_help=False)
     argument_parsers.append(parser)
-    argparse_name_registry.reserve('f', 'file', 'd', 'dump', 'v', 'validate')
+    argparse_name_registry.reserve('f', 'file', 'd', 'dump', 'validate')
     parser.add_argument('-f',
                         '--file',
                         type=str,
@@ -140,7 +140,6 @@ def get_hparams_file_from_cli(
         help='Dump the resulting Hparams to the specified YAML file (defaults to `stdout`) and exit.',
     )
     parser.add_argument(
-        '-v',
         '--validate',
         action='store_true',
         help='Whether to validate YAML against Hparams.',

--- a/yahp/create_object/argparse.py
+++ b/yahp/create_object/argparse.py
@@ -117,10 +117,10 @@ def get_hparams_file_from_cli(
     cli_args: List[str],
     argparse_name_registry: ArgparseNameRegistry,
     argument_parsers: List[argparse.ArgumentParser],
-) -> Tuple[Optional[str], Optional[str]]:
+) -> Tuple[Optional[str], Optional[str], Optional[str]]:
     parser = argparse.ArgumentParser(add_help=False)
     argument_parsers.append(parser)
-    argparse_name_registry.reserve('f', 'file', 'd', 'dump')
+    argparse_name_registry.reserve('f', 'file', 'd', 'dump', 'v', 'validate')
     parser.add_argument('-f',
                         '--file',
                         type=str,
@@ -139,8 +139,14 @@ def get_hparams_file_from_cli(
         metavar='stdout',
         help='Dump the resulting Hparams to the specified YAML file (defaults to `stdout`) and exit.',
     )
+    parser.add_argument(
+        '-v',
+        '--validate',
+        action='store_true',
+        help='Whether to validate YAML against Hparams.',
+    )
     parsed_args, cli_args[:] = parser.parse_known_args(cli_args)
-    return parsed_args.file, parsed_args.dump
+    return parsed_args.file, parsed_args.dump, parsed_args.validate
 
 
 def get_commented_map_options_from_cli(
@@ -185,38 +191,6 @@ def get_commented_map_options_from_cli(
         return  # don't generate a template
 
     return parsed_args.save_template, parsed_args.interactive, not parsed_args.concise
-
-
-def validate_hparams_file_from_cli(
-    *,
-    cli_args: List[str],
-    argparse_name_registry: ArgparseNameRegistry,
-    argument_parsers: List[argparse.ArgumentParser],
-) -> Tuple[Optional[str], Optional[str], Optional[bool]]:
-    parser = argparse.ArgumentParser(add_help=False)
-    argument_parsers.append(parser)
-    argparse_name_registry.reserve('validate_file', 'validate_data', 'v', 'validate')
-    parser.add_argument('--validate_file',
-                        type=str,
-                        default=None,
-                        required=False,
-                        help='Load data from this YAML file to validate against Hparams.')
-    parser.add_argument(
-        '--validate_data',
-        type=str,
-        default=None,
-        required=False,
-        help='YAML string used to validate against Hparams.',
-    )
-    parser.add_argument(
-        '-v',
-        '--validate',
-        action='store_true',
-        required=False,
-        help='Whether to validate YAML against Hparams.',
-    )
-    parsed_args, cli_args[:] = parser.parse_known_args(cli_args)
-    return parsed_args.validate_file, parsed_args.validate_data, parsed_args.validate
 
 
 def cli_parse(val: Union[str, _MISSING_TYPE]) -> Union[str, None, _MISSING_TYPE]:

--- a/yahp/create_object/argparse.py
+++ b/yahp/create_object/argparse.py
@@ -192,20 +192,17 @@ def validate_hparams_file_from_cli(
     cli_args: List[str],
     argparse_name_registry: ArgparseNameRegistry,
     argument_parsers: List[argparse.ArgumentParser],
-) -> Tuple[Optional[str], Optional[str]]:
+) -> Tuple[Optional[str], Optional[str], Optional[bool]]:
     parser = argparse.ArgumentParser(add_help=False)
     argument_parsers.append(parser)
-    argparse_name_registry.reserve('f', 'file', 'd', 'dump', 'v', 'validate')
-    parser.add_argument('-f',
-                        '--file',
+    argparse_name_registry.reserve('validate_file', 'validate_data', 'v', 'validate')
+    parser.add_argument('--validate_file',
                         type=str,
                         default=None,
-                        dest='file',
                         required=False,
                         help='Load data from this YAML file to validate against Hparams.')
     parser.add_argument(
-        '-d',
-        '--data',
+        '--validate_data',
         type=str,
         default=None,
         required=False,
@@ -214,12 +211,12 @@ def validate_hparams_file_from_cli(
     parser.add_argument(
         '-v',
         '--validate',
-        type=bool,
         action='store_true',
+        required=False,
         help='Whether to validate YAML against Hparams.',
     )
     parsed_args, cli_args[:] = parser.parse_known_args(cli_args)
-    return parsed_args.file, parsed_args.data, parsed_args.validate
+    return parsed_args.validate_file, parsed_args.validate_data, parsed_args.validate
 
 
 def cli_parse(val: Union[str, _MISSING_TYPE]) -> Union[str, None, _MISSING_TYPE]:

--- a/yahp/create_object/argparse.py
+++ b/yahp/create_object/argparse.py
@@ -187,6 +187,41 @@ def get_commented_map_options_from_cli(
     return parsed_args.save_template, parsed_args.interactive, not parsed_args.concise
 
 
+def validate_hparams_file_from_cli(
+    *,
+    cli_args: List[str],
+    argparse_name_registry: ArgparseNameRegistry,
+    argument_parsers: List[argparse.ArgumentParser],
+) -> Tuple[Optional[str], Optional[str]]:
+    parser = argparse.ArgumentParser(add_help=False)
+    argument_parsers.append(parser)
+    argparse_name_registry.reserve('f', 'file', 'd', 'dump', 'v', 'validate')
+    parser.add_argument('-f',
+                        '--file',
+                        type=str,
+                        default=None,
+                        dest='file',
+                        required=False,
+                        help='Load data from this YAML file to validate against Hparams.')
+    parser.add_argument(
+        '-d',
+        '--data',
+        type=str,
+        default=None,
+        required=False,
+        help='YAML string used to validate against Hparams.',
+    )
+    parser.add_argument(
+        '-v',
+        '--validate',
+        type=bool,
+        action='store_true',
+        help='Whether to validate YAML against Hparams.',
+    )
+    parsed_args, cli_args[:] = parser.parse_known_args(cli_args)
+    return parsed_args.file, parsed_args.data, parsed_args.validate
+
+
 def cli_parse(val: Union[str, _MISSING_TYPE]) -> Union[str, None, _MISSING_TYPE]:
     # Helper to parse CLI input
     # Almost like the default of `str`, but handles MISSING and "none" gracefully

--- a/yahp/create_object/create_object.py
+++ b/yahp/create_object/create_object.py
@@ -16,8 +16,8 @@ from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence
 import yaml
 
 from yahp.auto_hparams import ensure_hparams_cls
-from yahp.create_object.argparse import (ArgparseNameRegistry, ParserArgument, get_commented_map_options_from_cli, validate_hparams_file_from_cli,
-                                         get_hparams_file_from_cli, retrieve_args)
+from yahp.create_object.argparse import (ArgparseNameRegistry, ParserArgument, get_commented_map_options_from_cli,
+                                         get_hparams_file_from_cli, retrieve_args, validate_hparams_file_from_cli)
 from yahp.hparams import Hparams
 from yahp.inheritance import load_yaml_with_inheritance
 from yahp.serialization import register_hparams_for_instance, register_hparams_registry_key_for_instance
@@ -644,14 +644,13 @@ def _get_hparams(
         argument_parsers=argparsers,
     )
     if v_options is not None:
-        input_file, data, validate = v_options
+        validate_file, validate_data, validate = v_options
         if validate:
-            print(f'Validating YAML against {constructor.__name__}')
+            print(f'Validating YAML against {constructor.__name__}...')
             cls = ensure_hparams_cls(constructor)
-            cls.validate_yaml(f=input_file, data=data)
+            cls.validate_yaml(f=validate_file, data=validate_data)
             # exit so we don't attempt to parse and instantiate
-            print()
-            print('Finished')
+            print('\nSuccessfully validated YAML!')
             sys.exit(0)
 
     cm_options = get_commented_map_options_from_cli(
@@ -661,7 +660,7 @@ def _get_hparams(
     )
     if cm_options is not None:
         output_file, interactive, add_docs = cm_options
-        print(f'Generating a template for {constructor.__name__}')
+        print(f'Generating a template for {constructor.__name__}...')
         cls = ensure_hparams_cls(constructor)
         if output_file == 'stdout':
             cls.dump(add_docs=add_docs, interactive=interactive, output=sys.stdout)
@@ -671,8 +670,7 @@ def _get_hparams(
             with open(output_file, 'x') as f:
                 cls.dump(add_docs=add_docs, interactive=interactive, output=f)
         # exit so we don't attempt to parse and instantiate if generate template is passed
-        print()
-        print('Finished')
+        print('\nFinished')
         sys.exit(0)
 
     cli_f, output_f = get_hparams_file_from_cli(cli_args=remaining_cli_args,

--- a/yahp/hparams.py
+++ b/yahp/hparams.py
@@ -336,7 +336,6 @@ class Hparams(ABC):
         res = {
             'type': 'object',
             'properties': {},
-            'required': [],
             'additionalProperties': False,
         }
         class_type_hints = get_type_hints(cls)
@@ -346,6 +345,8 @@ class Hparams(ABC):
 
             # Required field
             if type_helpers.is_field_required(f):
+                if 'required' not in res.keys():
+                    res['required'] = []
                 res['required'].append(f.name)
 
             hparams_type = type_helpers.HparamsType(class_type_hints[f.name])
@@ -355,10 +356,6 @@ class Hparams(ABC):
             else:
                 res['properties'][f.name] = get_type_json_schema(hparams_type)
             res['properties'][f.name]['description'] = f.metadata['doc']
-
-        # Delete required list if no fields are required
-        if len(res['required']) == 0:
-            del res['required']
 
         return res
 
@@ -374,7 +371,7 @@ class Hparams(ABC):
     @classmethod
     def validate_yaml(cls: Type[THparams],
                       f: Union[str, None, TextIO, pathlib.PurePath] = None,
-                      data: Optional[str] = None):
+                      data: Optional[Dict[str, Any]] = None):
         """Validate yaml against JSON schema.
 
         Args:
@@ -395,7 +392,7 @@ class Hparams(ABC):
                 with open(f) as file:
                     jsonschema.validate(yaml.safe_load(file), cls.get_json_schema())
         elif data:
-            jsonschema.validate(yaml.safe_load(data), cls.get_json_schema())
+            jsonschema.validate(data, cls.get_json_schema())
         else:
             raise ValueError('Neither file nor data were provided, so there is no YAML to validate.')
 

--- a/yahp/hparams.py
+++ b/yahp/hparams.py
@@ -12,7 +12,7 @@ import warnings
 from abc import ABC
 from dataclasses import MISSING, dataclass, fields
 from enum import Enum
-from io import StringIO
+from io import StringIO, TextIOWrapper
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, TextIO, Type, TypeVar, Union, cast
 
 import jsonschema
@@ -361,10 +361,10 @@ class Hparams(ABC):
     @classmethod
     def dump_jsonschema(cls, f: Union[TextIO, str, pathlib.Path]):
         """Dump the JSONSchema to ``f``."""
-        if isinstance(f, TextIO):
+        if isinstance(f, TextIO) or isinstance(f, TextIOWrapper):
             json.dump(cls.get_json_schema(), f)
         else:
-            with open(f) as file:
+            with open(f, 'w') as file:
                 json.dump(cls.get_json_schema(), file)
 
     @classmethod
@@ -385,7 +385,7 @@ class Hparams(ABC):
         if f and data:
             raise ValueError('File and data cannot both be specified.')
         elif f:
-            if isinstance(f, TextIO):
+            if isinstance(f, TextIO) or isinstance(f, TextIOWrapper):
                 jsonschema.validate(yaml.safe_load(f), cls.get_json_schema())
             else:
                 with open(f) as file:

--- a/yahp/hparams.py
+++ b/yahp/hparams.py
@@ -20,7 +20,7 @@ import yaml
 
 from yahp.utils import type_helpers
 from yahp.utils.iter_helpers import list_to_deduplicated_dict
-from yahp.utils.json_schema_helpers import get_type_json_schema
+from yahp.utils.json_schema_helpers import get_registry_json_schema, get_type_json_schema
 
 if TYPE_CHECKING:
     from yahp.types import JSON
@@ -349,7 +349,11 @@ class Hparams(ABC):
                 res['required'].append(f.name)
 
             hparams_type = type_helpers.HparamsType(class_type_hints[f.name])
-            res['properties'][f.name] = get_type_json_schema(hparams_type)
+            # Name is found in registry, set possible values as types in a union type
+            if cls.hparams_registry and f.name in cls.hparams_registry and len(cls.hparams_registry[f.name].keys()) > 0:
+                res['properties'][f.name] = get_registry_json_schema(hparams_type, cls.hparams_registry[f.name])
+            else:
+                res['properties'][f.name] = get_type_json_schema(hparams_type)
             res['properties'][f.name]['description'] = f.metadata['doc']
 
         # Delete required list if no fields are required

--- a/yahp/hparams.py
+++ b/yahp/hparams.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import argparse
+import inspect
+import json
+import jsonschema
 import logging
 import pathlib
 import textwrap
 import warnings
 from abc import ABC
-from dataclasses import dataclass, fields
+from dataclasses import MISSING, dataclass, fields
 from enum import Enum
 from io import StringIO
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, TextIO, Type, TypeVar, Union, cast
@@ -325,6 +328,73 @@ class Hparams(ABC):
             category=DeprecationWarning,
         )
 
+    @classmethod
+    def get_json_schema(cls) -> Dict[str, Any]:
+        """Generates and returns a JSONSchema dictionary."""
+        
+        res: Dict[str, JSON] = {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        }
+        for f in fields(cls):
+            if not f.init:
+                continue
+
+            # Required field
+            if f.default == MISSING:
+                res["required"].append(f.name)
+
+            # Hparams, recurse
+            if inspect.isclass(f.type) and issubclass(f.type, Hparams):
+                res["properties"][f.name] = f.type.get_json_schema()
+            # Otherwise, build schema for type
+            else:
+                res["properties"][f.name] = type_helpers.get_type_json_schema(f.type)
+
+        # Delete required list if no fields are required
+        if len(res["required"]) == 0:
+            del res["required"]
+
+        return res
+
+    @classmethod
+    def dump_jsonschema(cls, f: Union[TextIO, str, pathlib.Path]):
+        """Dump the JSONSchema to ``f``."""
+        if type(f) == TextIO:
+            json.dump(type_helpers.get_type_json_schema(), f)
+        else:
+            with open(f) as file:
+                json.dump(type_helpers.get_type_json_schema(), file)
+
+    @classmethod
+    def validate_yaml(
+        cls: Type[THparams],
+        f: Union[str, None, TextIO, pathlib.PurePath] = None,
+        data: Optional[str] = None
+    ):
+        """Validate yaml against JSON schema.
+
+        Args:
+            f (Union[str, None, TextIO, pathlib.PurePath], optional):
+                If specified, loads values and validates from a YAML file. Can be either a
+                filepath or file-like object. 
+                Cannot be specified with ``data``.
+            data (Optional[str], optional):
+                If specified, validates YAML specified by string :class:`Hparams`. 
+                Cannot be specified with ``f``.
+        """
+        if f and data:
+            raise ValueError('File and data cannot both be specified.')
+        elif f:
+            if type(f) == TextIO:
+                jsonschema.validate(yaml.safe_load(f), cls.get_json_schema())
+            else:
+                with open(f) as file:
+                    jsonschema.validate(yaml.safe_load(file), cls.get_json_schema())
+        elif data:
+            jsonschema.validate(yaml.safe_load(data), cls.get_json_schema())
+        
     def __str__(self) -> str:
         yaml_str = self.to_yaml().strip()
         yaml_str = textwrap.indent(yaml_str, '  ')

--- a/yahp/utils/json_schema_helpers.py
+++ b/yahp/utils/json_schema_helpers.py
@@ -1,0 +1,59 @@
+from enum import Enum
+import inspect
+
+from yahp.utils import type_helpers
+
+
+def get_type_json_schema(f_type: type_helpers.HparamsType):
+    print(f_type, f_type.types[0], callable(f_type.types[0]))
+    # Import inside function to resovle circular dependencies
+    from yahp.auto_hparams import ensure_hparams_cls
+
+    res = {}
+    # List
+    if f_type.is_list:
+        res = {'type': 'array', 'items': {'type': get_list_type_json_schema(f_type)}}
+        # Remove additional properties if its empty, such as if value_type is JSON
+        if len(res['items']['type'].keys()) == 0:
+            del res['items']
+    # Union
+    if len(f_type.types) > 1:
+        res = get_list_type_json_schema(f_type)
+    # Primitive Types
+    if f_type.types[0] is str:
+        res = {'type': 'string'}
+    elif f_type.types[0] is bool:
+        res = {'type': 'boolean'}
+    elif f_type.types[0] is int:
+        res = {'type': 'integer'}
+    elif f_type.types[0] is float:
+        res = {'type': 'number'}
+    # Enum
+    elif inspect.isclass(f_type.types[0]) and issubclass(f_type.types[0], Enum):
+        # Enum attributes can either be specified lowercase or uppercase
+        member_names = [name.lower() for name in f_type.types[0]._member_names_]
+        member_names.extend([name.upper() for name in f_type.types[0]._member_names_])
+        res = {'enum': member_names}
+    elif f_type.types[0] == type_helpers._JSONDict:
+        res = {
+            'type': 'object',
+        }
+    # Hparam class
+    elif callable(f_type.types[0]):
+        hparam_class = ensure_hparams_cls(f_type.types[0])
+        return hparam_class.get_json_schema()
+    # JSON
+    else:
+        raise ValueError("Unexpected type when constructing JSON Schema.")
+    return res
+
+
+def get_list_type_json_schema(f_type: type_helpers.HparamsType):
+    if len(f_type.types) > 1:
+        # Add all union types using oneOf
+        res = {'oneOf': []}
+        for union_type in f_type.types:
+            res['oneOf'].append(get_list_type_json_schema(type_helpers.HparamsType(union_type)))
+    else:
+        res = {'type': f_type.types[0]}
+    return res

--- a/yahp/utils/json_schema_helpers.py
+++ b/yahp/utils/json_schema_helpers.py
@@ -1,25 +1,42 @@
 import inspect
 from enum import Enum
+from typing import Any, Dict
 
 from yahp.utils import type_helpers
 
 
+def get_registry_json_schema(f_type: type_helpers.HparamsType, registry: Dict[str, Any]):
+    """Convert type into corresponding JSON Schema. As the given name is in the `hparams_registry`,
+    create objects for each possible entry in the registry and treat as union type.
+    """
+    res = {'oneOf': []}
+    for key, value in registry.items():
+        res['oneOf'].append({
+            'type': 'object',
+            'properties': {
+                key: get_type_json_schema(type_helpers.HparamsType(value))
+            },
+            'additionalProperties': False,
+        })
+    return check_for_list_and_optional(f_type, res)
+
+
 def get_type_json_schema(f_type: type_helpers.HparamsType):
-    # Import inside function to resovle circular dependencies
+    """Convert type into corresponding JSON Schema.
+    """
+    # Import inside function to resolve circular dependencies
     from yahp.auto_hparams import ensure_hparams_cls
 
     res = {}
-    # List
-    if f_type.is_list:
-        res = {'type': 'array', 'items': {'type': get_list_type_json_schema(f_type)}}
-        # Remove additional properties if its empty, such as if value_type is JSON
-        if len(res['items']['type'].keys()) == 0:
-            del res['items']
+
     # Union
     if len(f_type.types) > 1:
-        res = get_list_type_json_schema(f_type)
+        # Add all union types using oneOf
+        res = {'oneOf': []}
+        for union_type in f_type.types:
+            res['oneOf'].append(get_type_json_schema(type_helpers.HparamsType(union_type)))
     # Primitive Types
-    if f_type.types[0] is str:
+    elif f_type.types[0] is str:
         res = {'type': 'string'}
     elif f_type.types[0] is bool:
         res = {'type': 'boolean'}
@@ -33,6 +50,7 @@ def get_type_json_schema(f_type: type_helpers.HparamsType):
         member_names = [name.lower() for name in f_type.types[0]._member_names_]
         member_names.extend([name.upper() for name in f_type.types[0]._member_names_])
         res = {'enum': member_names}
+    # JSON
     elif f_type.types[0] == type_helpers._JSONDict:
         res = {
             'type': 'object',
@@ -40,28 +58,31 @@ def get_type_json_schema(f_type: type_helpers.HparamsType):
     # Hparam class
     elif callable(f_type.types[0]):
         hparam_class = ensure_hparams_cls(f_type.types[0])
-        return hparam_class.get_json_schema()
-    # JSON
+        res = hparam_class.get_json_schema()
     else:
         raise ValueError('Unexpected type when constructing JSON Schema.')
+
+    return check_for_list_and_optional(f_type, res)
+
+
+def check_for_list_and_optional(f_type: type_helpers.HparamsType, schema: Dict[str, Any]) -> Dict[str, Any]:
+    """Wrap JSON Schema with list schema or optional schema if specified.
+    """
+    res = schema
+    # Wrap type in list
+    if f_type.is_list:
+        res = {
+            'type': 'array',
+            'items': res,
+        }
+    # Wrap type for optional
     if f_type.is_optional:
         res = {
-            'anyOf': [
+            'oneOf': [
                 {
                     'type': 'null'
                 },
                 res,
             ]
         }
-    return res
-
-
-def get_list_type_json_schema(f_type: type_helpers.HparamsType):
-    if len(f_type.types) > 1:
-        # Add all union types using oneOf
-        res = {'oneOf': []}
-        for union_type in f_type.types:
-            res['oneOf'].append(get_list_type_json_schema(type_helpers.HparamsType(union_type)))
-    else:
-        res = {'type': f_type.types[0]}
     return res

--- a/yahp/utils/json_schema_helpers.py
+++ b/yahp/utils/json_schema_helpers.py
@@ -1,11 +1,10 @@
-from enum import Enum
 import inspect
+from enum import Enum
 
 from yahp.utils import type_helpers
 
 
 def get_type_json_schema(f_type: type_helpers.HparamsType):
-    print(f_type, f_type.types[0], callable(f_type.types[0]))
     # Import inside function to resovle circular dependencies
     from yahp.auto_hparams import ensure_hparams_cls
 
@@ -44,7 +43,16 @@ def get_type_json_schema(f_type: type_helpers.HparamsType):
         return hparam_class.get_json_schema()
     # JSON
     else:
-        raise ValueError("Unexpected type when constructing JSON Schema.")
+        raise ValueError('Unexpected type when constructing JSON Schema.')
+    if f_type.is_optional:
+        res = {
+            'anyOf': [
+                {
+                    'type': 'null'
+                },
+                res,
+            ]
+        }
     return res
 
 

--- a/yahp/utils/json_schema_helpers.py
+++ b/yahp/utils/json_schema_helpers.py
@@ -18,11 +18,14 @@ def get_registry_json_schema(f_type: type_helpers.HparamsType, registry: Dict[st
             },
             'additionalProperties': False,
         })
-    return check_for_list_and_optional(f_type, res)
+    return _check_for_list_and_optional(f_type, res)
 
 
 def get_type_json_schema(f_type: type_helpers.HparamsType):
-    """Convert type into corresponding JSON Schema.
+    """Convert type into corresponding JSON Schema. We first check for union types and recursively
+    handle each component. If a type is not union, we know it is a singleton type, so it must be
+    either a primitive, Enum, JSON, or Hparam-like. Dictionaries are treated as JSON types, and
+    list and optionals are handled in a post-processing step in `_check_for_list_and_optional`.
     """
     # Import inside function to resolve circular dependencies
     from yahp.auto_hparams import ensure_hparams_cls
@@ -36,36 +39,36 @@ def get_type_json_schema(f_type: type_helpers.HparamsType):
         for union_type in f_type.types:
             res['anyOf'].append(get_type_json_schema(type_helpers.HparamsType(union_type)))
     # Primitive Types
-    elif f_type.types[0] is str:
+    elif f_type.type is str:
         res = {'type': 'string'}
-    elif f_type.types[0] is bool:
+    elif f_type.type is bool:
         res = {'type': 'boolean'}
-    elif f_type.types[0] is int:
+    elif f_type.type is int:
         res = {'type': 'integer'}
-    elif f_type.types[0] is float:
+    elif f_type.type is float:
         res = {'type': 'number'}
     # Enum
-    elif inspect.isclass(f_type.types[0]) and issubclass(f_type.types[0], Enum):
+    elif inspect.isclass(f_type.type) and issubclass(f_type.type, Enum):
         # Enum attributes can either be specified lowercase or uppercase
-        member_names = [name.lower() for name in f_type.types[0]._member_names_]
-        member_names.extend([name.upper() for name in f_type.types[0]._member_names_])
+        member_names = [name.lower() for name in f_type.type._member_names_]
+        member_names.extend([name.upper() for name in f_type.type._member_names_])
         res = {'enum': member_names}
     # JSON
-    elif f_type.types[0] == type_helpers._JSONDict:
+    elif f_type.type == type_helpers._JSONDict:
         res = {
             'type': 'object',
         }
     # Hparam class
-    elif callable(f_type.types[0]):
-        hparam_class = ensure_hparams_cls(f_type.types[0])
+    elif callable(f_type.type):
+        hparam_class = ensure_hparams_cls(f_type.type)
         res = hparam_class.get_json_schema()
     else:
         raise ValueError('Unexpected type when constructing JSON Schema.')
 
-    return check_for_list_and_optional(f_type, res)
+    return _check_for_list_and_optional(f_type, res)
 
 
-def check_for_list_and_optional(f_type: type_helpers.HparamsType, schema: Dict[str, Any]) -> Dict[str, Any]:
+def _check_for_list_and_optional(f_type: type_helpers.HparamsType, schema: Dict[str, Any]) -> Dict[str, Any]:
     """Wrap JSON Schema with list schema or optional schema if specified.
     """
     res = schema

--- a/yahp/utils/json_schema_helpers.py
+++ b/yahp/utils/json_schema_helpers.py
@@ -9,9 +9,9 @@ def get_registry_json_schema(f_type: type_helpers.HparamsType, registry: Dict[st
     """Convert type into corresponding JSON Schema. As the given name is in the `hparams_registry`,
     create objects for each possible entry in the registry and treat as union type.
     """
-    res = {'oneOf': []}
+    res = {'anyOf': []}
     for key, value in registry.items():
-        res['oneOf'].append({
+        res['anyOf'].append({
             'type': 'object',
             'properties': {
                 key: get_type_json_schema(type_helpers.HparamsType(value))
@@ -31,10 +31,10 @@ def get_type_json_schema(f_type: type_helpers.HparamsType):
 
     # Union
     if len(f_type.types) > 1:
-        # Add all union types using oneOf
-        res = {'oneOf': []}
+        # Add all union types using anyOf
+        res = {'anyOf': []}
         for union_type in f_type.types:
-            res['oneOf'].append(get_type_json_schema(type_helpers.HparamsType(union_type)))
+            res['anyOf'].append(get_type_json_schema(type_helpers.HparamsType(union_type)))
     # Primitive Types
     elif f_type.types[0] is str:
         res = {'type': 'string'}

--- a/yahp/utils/type_helpers.py
+++ b/yahp/utils/type_helpers.py
@@ -6,13 +6,10 @@ import inspect
 import json
 from dataclasses import MISSING, Field
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, Sequence, Tuple, Type, Union, cast
+from typing import Any, Dict, Sequence, Tuple, Type, Union, cast
 
 from yahp.utils.iter_helpers import ensure_tuple
 from yahp.utils.typing_future import get_args, get_origin
-
-if TYPE_CHECKING:
-    from yahp.types import JSON
 
 
 class _JSONDict:  # sentential for representing JSON dictionary types
@@ -418,7 +415,7 @@ def is_none_like(x: Any, *, allow_list: bool) -> bool:
     return False
 
 
-def get_type_json_schema(f_type: Any) -> JSON:
+def get_type_json_schema(f_type: Any):
     res = {}
     # Primitive Types
     if f_type is str:

--- a/yahp/utils/type_helpers.py
+++ b/yahp/utils/type_helpers.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import json
 from dataclasses import MISSING, Field
 from enum import Enum
-from typing import Any, Dict, Sequence, Tuple, Type, Union, cast
+import inspect
+from typing import TYPE_CHECKING, Any, Dict, Sequence, Tuple, Type, Union, cast, ForwardRef, List
 
 from yahp.utils.iter_helpers import ensure_tuple
 from yahp.utils.typing_future import get_args, get_origin
+if TYPE_CHECKING:
+    from yahp.types import JSON
 
 
 class _JSONDict:  # sentential for representing JSON dictionary types
@@ -412,3 +415,89 @@ def is_none_like(x: Any, *, allow_list: bool) -> bool:
     if allow_list and isinstance(x, (tuple, list)) and len(x) == 1:
         return is_none_like(x[0], allow_list=allow_list)
     return False
+
+def get_type_json_schema(f_type: Any) -> JSON:
+    res: Dict[str, JSON] = {}
+    # Primitive Types
+    if f_type is str:
+        res = {
+            "type": "string"
+        }
+    elif f_type is bool:
+        res = {
+            "type": "boolean"
+        }
+    elif f_type is int:
+        res = {
+            "type": "integer"
+        }
+    elif f_type is float:
+        res = {
+            "type": "number"
+        }
+    # List
+    elif f_type is list:
+        res = {
+            "type": "array"
+        }
+    # typing.List
+    elif hasattr(f_type, '__origin__') and f_type.__origin__ is list:
+        list_type = f_type.__args__[0]
+        res = {
+            "type": "array",
+            "items": {
+                "type": get_type_json_schema(list_type)
+            }
+        }
+        # Remove additional properties if its empty, such as if value_type is JSON
+        if len(res["items"]["type"].keys()) == 0:
+            del res["items"]
+    # dict
+    elif f_type is dict:
+        res = {
+            "type": "object",
+        }
+    # typing.Dict
+    elif hasattr(f_type, '__origin__') and f_type.__origin__ is dict:
+        # Note that we are unable to type key values as they must be strings in JSONs.
+        _, value_type = f_type.__args__
+        res = {
+            "type": "object",
+            "additionalProperties": get_type_json_schema(value_type)
+        }
+        # Remove additional properties if its empty, such as if value_type is JSON
+        if len(res["additionalProperties"].keys()) == 0:
+            del res["additionalProperties"]
+    # typing.Union
+    elif hasattr(f_type, '__origin__') and f_type.__origin__ is Union:
+        # Type introspection shows JSON by giving a union of all types. If we have JSON, return {} and 
+        # apply no typing restrictions
+        json_type = [str, float, int, type(None), List[ForwardRef('JSON')], Dict[str, ForwardRef('JSON')]]
+        union_types = f_type.__args__
+        is_json = True
+        for json_type_part in json_type:
+            if json_type_part not in union_types:
+                is_json = False
+                break
+        if is_json:
+            return {}
+        # Add all union types using oneOf
+        res = {
+            "oneOf": []
+        }
+        for union_type in union_types:
+            res["oneOf"].append(get_type_json_schema(union_type))
+    # Enum
+    elif inspect.isclass(f_type) and issubclass(f_type, Enum):
+        # Enum attributes can either be specified lowercase or uppercase
+        member_names = [name.lower() for name in f_type._member_names_]
+        member_names.extend([name.upper() for name in f_type._member_names_])
+        res = {
+            "enum": member_names
+        }
+    # Object
+    else:
+        res = {
+            "type": "object",
+        }
+    return res


### PR DESCRIPTION
- Lets YAHP autogenerate JSON Schemas
- Supports static validation through function call and CLI

[Associated](https://mosaicml.atlassian.net/browse/CO-669) [JIRAs](https://mosaicml.atlassian.net/browse/CO-670)