### PR TITLE
Fix List of Hparams

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ reportUnusedCoroutine = "error"
 [tool.pytest.ini_options]
 filterwarnings = [
     "error",
-    "ignore:ExtraArgumentWarning",
     '''ignore:.*validate\(\) is deprecated:DeprecationWarning''',
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,16 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
 
+import sys
+
+import pytest
+
 # Add the path of any pytest fixture files you want to make global
 pytest_plugins = [
     'tests.yahp_fixtures',
 ]
+
+
+@pytest.fixture(autouse=True)
+def patch_sys_argv(monkeypatch: pytest.MonkeyPatch):
+    """Patch the sys.argv by default to exclude all pytest CLI flags."""
+    monkeypatch.setattr(sys, 'argv', [sys.argv[0]])

--- a/tests/fixtures/commented_map.yaml
+++ b/tests/fixtures/commented_map.yaml
@@ -34,14 +34,12 @@ nullable_required_subhparams_field:
   default_true: true                         #                 bool (Optional). Description: defaults to true.
 # List[OptionalBooleansHparam] (Required). Description: required_subhparams_field.
 required_subhparams_field_list:
-  '0':
-    default_false: true
-    default_true: true
+- default_false: true
+  default_true: true
 # Optional[List[OptionalBooleansHparam]] (Required). Description: nullable_required_subhparams_field.
 nullable_required_subhparams_field_list:
-  '0':
-    default_false: false                     #                 bool (Optional). Description: defaults to false.
-    default_true: true                       #                 bool (Optional). Description: defaults to true.
+- default_false: false                       #                 bool (Optional). Description: defaults to false.
+  default_true: true                         #                 bool (Optional). Description: defaults to true.
 #   ChoiceHparamParent (Required). Description: choice Hparam field. Options: ChoiceOneHparam, ChoiceTwoHparam, ChoiceThreeHparam.
 required_choice:
   one:                                       # ChoiceOneHparam
@@ -172,9 +170,8 @@ optional_choice_default_not_none:
 optional_choice_default_none:
 # List[OptionalBooleansHparam] (Optional). Description: optional subhparams field default not none.
 optional_subhparams_field_default_not_none_list:
-  '0':
-    default_false: false
-    default_true: true
+- default_false: false
+  default_true: true
 # Optional[List[OptionalBooleansHparam]] (Optional). Description: optional subhparams field default None. Defaults to None.
 optional_subhparams_field_default_none_list:
 # List[ChoiceHparamParent] (Optional). Description: choice Hparam field. Options: ChoiceOneHparam, ChoiceTwoHparam, ChoiceThreeHparam.

--- a/yahp/create_object/commented_map.py
+++ b/yahp/create_object/commented_map.py
@@ -209,7 +209,7 @@ def to_commented_map(
                 if not ftype.is_list:
                     output[f.name] = output[f.name][0]
                 else:
-                    output[f.name] = {str(i): item for i, item in enumerate(output[f.name])}
+                    output[f.name] = output[f.name]
         else:
             inverted_hparams = {v: k for (k, v) in cls.hparams_registry[f.name].items()}
             choices = [x.__name__ for x in cls.hparams_registry[f.name].values()]


### PR DESCRIPTION
Fix a bug where concrete list of hparams required an extra level of dictionary. For example, given a dataclass of:

```python
@dataclass
class Foo(hp.Hparams):
    baz: int = hp.required(doc='int')

@dataclass
class ParentListHPNoRegistry(hp.Hparams):
    foos: List[Foo] = hp.required(doc='All the foos')
```

The following YAML should be allowed:

```yaml
foos:
  - baz: 2
  - baz: 3
```

Before, one had to specify a phantom key in the yaml, like this:

```yaml
foos:
  foo+1:
    - baz: 2
  foo+2:
     - baz: 3
```

The old syntax is still allowed, but now raises a deprecation warning. This is a non-breaking change.

Closes https://mosaicml.atlassian.net/browse/CO-766