### PR TITLE
Allow hp field description strings to contain `%`

### DIFF
--- a/tests/test_auto_field.py
+++ b/tests/test_auto_field.py
@@ -63,6 +63,17 @@ def malformed_docstring(foo: str):
     """
 
 
+class DocstringWithPercentFormat:
+    """Test that autoyahp can parse docstrings with percents in them.
+
+    Args:
+        foo (str): 100% for the win!
+    """
+
+    def __init__(self, foo: str) -> None:
+        self.foo = foo
+
+
 @pytest.fixture
 def mock_required_field(monkeypatch: pytest.MonkeyPatch):
     mock = Mock()
@@ -77,6 +88,12 @@ def mock_optional_field(monkeypatch: pytest.MonkeyPatch):
     mock.return_value = 'MOCK_RETURN'
     monkeypatch.setattr(yahp.field, 'optional', mock)
     return mock
+
+
+def test_docstrings_with_percent_format():
+    """Test that docstrings with % in them are parsable with --help in autoyahp."""
+    with pytest.raises(SystemExit):
+        hp.create(DocstringWithPercentFormat, cli_args=['--help'])
 
 
 @pytest.mark.parametrize('constructor', [FooClassDocstring, FooClassAndInitDocstring, foo_func])

--- a/yahp/create_object/argparse.py
+++ b/yahp/create_object/argparse.py
@@ -53,7 +53,9 @@ class ParserArgument:
             type=cli_parse,
             dest=self.full_name,
             const=True if self.nargs == '?' else None,
-            help=self.helptext,
+            # Replacing all % with %% to escape, so argparse does not attempt to
+            # interpolate it with an argparse variable
+            help=self.helptext.replace('%', '%%'),
             metavar=metavar,
         )
 


### PR DESCRIPTION
If calling `--help` on description that contains a `%`, argparse treats it as a format variable and crashes. Instead, all percents should be escaped in argparse help.

Added a test case to verify the fix.

Closes https://mosaicml.atlassian.net/browse/CO-558