### PR TITLE
Support backward compatibility for phantom key yamls

### DIFF
--- a/tests/test_yahp_phantom_keys.py
+++ b/tests/test_yahp_phantom_keys.py
@@ -1,0 +1,39 @@
+import contextlib
+import textwrap
+from typing import Type
+
+import pytest
+import yaml
+
+from tests.yahp_fixtures import HairyBearsHparams
+from yahp.hparams import Hparams
+
+@pytest.mark.parametrize('hparam_class,success,data', [
+    [
+        HairyBearsHparams, True,
+        textwrap.dedent("""
+            ---
+            bears:
+                - second_action: "Procure bears"
+                  third_action: "Release bears into wild with stylish new haircuts"
+                - second_action: "Procure bears"
+                  third_action: "Release bears into wild with stylish new haircuts"
+        """)
+    ],
+    [
+        HairyBearsHparams, False,
+        textwrap.dedent("""
+            ---
+            bears:
+                - bear:
+                    second_action: "Procure bears"
+                    third_action: "Release bears into wild with stylish new haircuts"
+                - hairybear:
+                    second_action: "Procure bears"
+                    third_action: "Release bears into wild with stylish new haircuts"
+        """)
+    ],
+])
+def test_create_yaml_with_phantom_keys(hparam_class: Type[Hparams], success: bool, data: str):
+    with contextlib.nullcontext() if success else pytest.raises(DeprecationWarning):
+        hparam_class.create(data=yaml.safe_load(data))

--- a/tests/test_yahp_phantom_keys.py
+++ b/tests/test_yahp_phantom_keys.py
@@ -8,6 +8,7 @@ import yaml
 from tests.yahp_fixtures import HairyBearsHparams
 from yahp.hparams import Hparams
 
+
 @pytest.mark.parametrize('hparam_class,success,data', [
     [
         HairyBearsHparams, True,

--- a/tests/yahp_fixtures.py
+++ b/tests/yahp_fixtures.py
@@ -654,3 +654,9 @@ class BearsHparams(hp.Hparams):
     }
 
     bears: Optional[List[Hparams]] = hp.required(doc='bear field')
+
+
+@dataclass
+class HairyBearsHparams(hp.Hparams):
+
+    bears: List[UnshavedBearsHparam] = hp.required(doc='bear field')

--- a/yahp/create_object/create_object.py
+++ b/yahp/create_object/create_object.py
@@ -276,6 +276,15 @@ def _create(
                                         break
                                 # unpack phantom keys
                                 if is_list_of_phantom_keys:
+                                    key_list = ', '.join([
+                                        list(sub_yaml_item.keys())[0]
+                                        for sub_yaml_item in sub_yaml
+                                        if isinstance(sub_yaml_item, dict)
+                                    ])
+                                    warnings.warn(
+                                        DeprecationWarning(
+                                            f'Ignoring the following keys: {key_list}. When specifying an object in a yaml, the object should be directly encoded instead of adding a phantom key. See https://stackoverflow.com/questions/33989612/yaml-equivalent-of-array-of-objects-in-json for an extended explanation.'
+                                        ))
                                     sub_yaml = unpacked_sub_yaml
 
                             if not isinstance(sub_yaml, list):

--- a/yahp/create_object/create_object.py
+++ b/yahp/create_object/create_object.py
@@ -259,6 +259,25 @@ def _create(
                                         f"{'.'.join(prefix_with_fname)} should be a list, not a dictionary"))
                                 sub_yaml = list(sub_yaml.values())
 
+                            # check for and unpack phantom keys for backward compatability
+                            if isinstance(sub_yaml, list):
+                                # check all items in list are phantom keys. If old syntax is being used, verify it
+                                # is used everywhere so we don't accidentally unpack a valid yaml based on this
+                                # heuristic
+                                is_list_of_phantom_keys = True
+                                unpacked_sub_yaml = []
+                                for sub_yaml_item in sub_yaml:
+                                    # heuristic for phantom keys: single key dict with dict value
+                                    if isinstance(sub_yaml_item, dict) and len(sub_yaml_item) == 1 and isinstance(
+                                            list(sub_yaml_item.values())[0], dict):
+                                        unpacked_sub_yaml.append(list(sub_yaml_item.values())[0])
+                                    else:
+                                        is_list_of_phantom_keys = False
+                                        break
+                                # unpack phantom keys
+                                if is_list_of_phantom_keys:
+                                    sub_yaml = unpacked_sub_yaml
+
                             if not isinstance(sub_yaml, list):
                                 raise TypeError(f'{full_name} must be a list in the yaml')
 


### PR DESCRIPTION
As title. We approximate if a yaml has a phantom key if each entry in a list is a singleton dict with a dict value. This resolves issues with new YAHP release [here](https://github.com/mosaicml/composer/pull/1325).